### PR TITLE
Fix urijs depedency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,6 @@
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "imgix-core-js": "1.0.3",
-    "uri.js": "~1.15.1"
+    "urijs": "~1.16.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
 
   included: function(app) {
     this.app.import(app.bowerDirectory + '/md5/build/md5.min.js');
-    this.app.import(app.bowerDirectory + '/uri.js/src/URI.js');
+    this.app.import(app.bowerDirectory + '/urijs/src/URI.js');
     this.app.import(app.bowerDirectory + '/js-base64/base64.js');
     this.app.import(app.bowerDirectory + '/imgix-core-js/dist/imgix-core-js.js');
   }


### PR DESCRIPTION
I believe this fixes #9. I've installed this package via npm from my fork and this branch, and `ember server` now works again with the bower `urljs` dependency installed.