### PR TITLE
Defer _incrementResizeCounter out of didInsertElement

### DIFF
--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -104,7 +104,7 @@ export default Ember.Mixin.create({
    * Fire off a resize after our element has been added to the DOM.
    */
   didInsertElement: function () {
-    this._incrementResizeCounter();
+    Ember.run.once(this, this._incrementResizeCounter);
   },
 
   /**


### PR DESCRIPTION
Fixes deprecation warning and associated performance issue in Ember 2.4.2. 

#12 