### PR TITLE
Don't generate src until _width can be determined

### DIFF
--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -68,6 +68,8 @@ export default Ember.Mixin.create({
    * @return the fully built string
    */
   src: computed('_path', '_query', '_width', '_height', '_dpr', 'crop', 'fit', function () {
+    if (!this.get('_width')) { return; }
+
     let env = this.get('_config');
 
     // These operations are defaults and should be overidden by any incoming

--- a/tests/unit/components/imgix-image-test.js
+++ b/tests/unit/components/imgix-image-test.js
@@ -51,6 +51,16 @@ test('it sets the source correctly', function(assert) {
   assert.ok(url.hasQuery("fit", "crop"));
 });
 
+test('it does not generate a source without a width', function(assert) {
+  var component = this.subject(defaultOptions);
+  component.setProperties({
+    path: "/users/1.png",
+    _width: null
+  });
+
+  assert.equal(null, component.get('src'));
+});
+
 test('it respects the pixel step', function(assert) {
   let component = this.subject(defaultOptions);
   component.setProperties({


### PR DESCRIPTION
In the sliver of time between DOM insertion and the deferred resize 
counter increment, the browser may attempt to load invalid image URLs
with `w=0` or `w=NaN`. On image-heavy pages, these invalid requests may
tie up some browsers' request queue, leading to a delay in loading the
correct URLs generated after the resize trigger fires.

This change causes `src` to return null until a `_width` is available.