### PR TITLE
Guard in Debounced calls

### DIFF
--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -143,6 +143,9 @@ export default Ember.Mixin.create({
    * @method _incrementResizeCounter
    */
   _incrementResizeCounter: function () {
+    if( this.get('isDestroyed') || this.get('isDestroying') ) {
+      return;
+    }
     this.incrementProperty('_resizeCounter');
   },
 


### PR DESCRIPTION
The debounced calls may be called when the object is destroyed and triggers an error because you can't set properties on destroyed objects.

This introduces a simple guard by checking `isDestroyed` and `isDestroying`