### PR TITLE
Update ember-cli-htmlbars dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.2.0",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.0",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "0.3.15",
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "^0.7.9",
+    "ember-cli-htmlbars": "^1.0.0",
     "ember-resize-mixin": "kellysutton/ember-resize-mixin#master"
   },
   "ember-addon": {


### PR DESCRIPTION
To avoid this deprecation warning under Ember 2.6+:

    DEPRECATION: Overriding init without calling this._super is deprecated. 
    Please call `this._super.init && this._super.init.apply(this, arguments);` 
    addon: `ember-cli-htmlbars`