### PR TITLE
Schedule _incrementResizeCounter in afterRender queue

### DIFF
--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -107,7 +107,7 @@ export default Ember.Mixin.create({
    * Fire off a resize after our element has been added to the DOM.
    */
   didInsertElement: function () {
-    Ember.run.once(this, this._incrementResizeCounter);
+    Ember.run.schedule('afterRender', this, this._incrementResizeCounter);
   },
 
   /**


### PR DESCRIPTION
Addresses a race condition in more recent ember versions where the
resize counter and width calculation could occur prior to the insertion
of a parent view.