### PR TITLE
Ensure jQuery selector is available

### DIFF
--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -177,7 +177,7 @@ export default Ember.Mixin.create({
   _width: computed('_resizeCounter', 'pixelStep', 'useParentWidth', function () {
     let newWidth = 0;
 
-    if (this.get('useParentWidth') && this.get('element')) {
+    if (this.$() && this.get('useParentWidth') && this.get('element')) {
       newWidth = this.$().parent().outerWidth();
     }
 


### PR DESCRIPTION
We need the parent element from the `img` tag to calculate its width. 
In latest ember with glimmer 2, (2.10.1) the element is not available in the DOM until later.