### PR TITLE
Avoid throwing TypeError when path is undefined

### DIFF
--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -32,8 +32,8 @@ export default Ember.Mixin.create({
    * @property {string} The computed path from the input path. This should not include any query parameters passed in, e.g. "/users/1.png?sat=100"
    */
   _path: computed('path', function() {
-    let uri = URI(this.get('path'));
-    return uri.pathname();
+    let path = this.get('path');
+    return path ? URI(path).pathname() : '';
   }),
 
   /**
@@ -41,8 +41,8 @@ export default Ember.Mixin.create({
    * @property {Object} a hash of key-value pairs for parameters that were passed in via the `path` property
    */
   _query: computed('path', function() {
-    let uri = URI(this.get('path'));
-    return Ember.Object.create(uri.search(true));
+    let path = this.get('path');
+    return path ? Ember.Object.create(URI(path).search(true)) : {};
   }),
 
   _widthFromPath: computed('_query', function() {

--- a/tests/unit/components/imgix-image-test.js
+++ b/tests/unit/components/imgix-image-test.js
@@ -32,6 +32,13 @@ test('it renders', function(assert) {
   assert.equal(component._state, 'inDOM');
 });
 
+test('it does not throw an exception when given an undefined path', function(assert) {
+  var component = this.subject(defaultOptions);
+  component.set('path', undefined);
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
 test('it sets the source correctly', function(assert) {
   var component = this.subject(defaultOptions);
   component.setProperties({


### PR DESCRIPTION
Passing a null or undefined path into the component was throwing an
exception along the lines of:

    TypeError: undefined is not a valid argument for URI

This adds an existence check on `path` before passing it to URI for parsing.