### PR TITLE
Remove bower dependency, incidental benefit of this change is that you can use this in nested addons.

### DIFF
--- a/blueprints/ember-cli-imgix/index.js
+++ b/blueprints/ember-cli-imgix/index.js
@@ -1,10 +1,3 @@
 module.exports = {
   normalizeEntityName: function() {},
-
-  afterInstall: function() {
-    return this.addBowerPackagesToProject([
-      { name: 'imgix-core-js', target: '1.0.3' },
-      { name: 'urijs', target: '~1.16.1' }
-    ]);
-  }
 };

--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,6 @@
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
-    "qunit": "~1.18.0",
-    "imgix-core-js": "1.0.3",
-    "urijs": "~1.16.1"
+    "qunit": "~1.18.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 module.exports = {
   name: 'ember-cli-imgix',
 
-  isDevelopingAddon() {
+  isDevelopingAddon: function() {
     return true;
   },
 

--- a/index.js
+++ b/index.js
@@ -4,14 +4,27 @@
 module.exports = {
   name: 'ember-cli-imgix',
 
-  isDevelopingAddon: function() {
+  isDevelopingAddon() {
     return true;
   },
 
-  included: function(app) {
-    this.app.import(app.bowerDirectory + '/md5/build/md5.min.js');
-    this.app.import(app.bowerDirectory + '/urijs/src/URI.js');
-    this.app.import(app.bowerDirectory + '/js-base64/base64.js');
-    this.app.import(app.bowerDirectory + '/imgix-core-js/dist/imgix-core-js.js');
-  }
+  options: {
+    nodeAssets: {
+      'blueimp-md5': {
+        srcDir: 'js',
+        import: ['md5.min.js'],
+      },
+      urijs: {
+        srcDir: 'src',
+        import: ['URI.min.js'],
+      },
+      'js-base64': {
+        import: ['base64.min.js'],
+      },
+      'imgix-core-js': {
+        srcDir: 'dist',
+        import: ['imgix-core-js.js'],
+      }
+    }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -42,10 +42,15 @@
     "responsive"
   ],
   "dependencies": {
+    "js-base64": "2.1.9",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.0",
     "ember-getowner-polyfill": "1.0.1",
-    "ember-resize-mixin": "kellysutton/ember-resize-mixin#master"
+    "ember-resize-mixin": "kellysutton/ember-resize-mixin#master",
+    "blueimp-md5": "2.7.0",
+    "urijs": "1.18.10",
+    "imgix-core-js": "1.0.5",
+    "ember-cli-node-assets": "0.2.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
- Removes bower dependencies in favor of npm for client dependencies
- Removes included hook in favor of ember-cli-node-assets to import client dependencies into ember vendor tree
- Removes `afterInstall` hook of blueprint as bower dependencies are no longer required