### PR TITLE
Remove ember-resize-mixin in favor of ember-resize

### DIFF
--- a/addon/components/imgix-image-element.js
+++ b/addon/components/imgix-image-element.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
-import ResizeMixin from 'ember-resize-mixin/main';
 import ImgixPathBehavior from '../mixins/imgix-path-behavior';
 
-export default Ember.Component.extend(ImgixPathBehavior, ResizeMixin, {
+export default Ember.Component.extend(ImgixPathBehavior, {
   tagName: 'img',
   layout: null,
   attributeBindings: ['src', 'crossorigin', 'style', 'alt'],

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -1,9 +1,8 @@
 import Ember from 'ember';
-import ResizeMixin from 'ember-resize-mixin/main';
 import layout from '../templates/components/imgix-image';
 import ImgixPathBehavior from '../mixins/imgix-path-behavior';
 
-export default Ember.Component.extend(ResizeMixin, ImgixPathBehavior, {
+export default Ember.Component.extend(ImgixPathBehavior, {
   layout: layout,
   classNames: ['imgix-image-wrap']
 });

--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -1,15 +1,21 @@
 import Ember from 'ember';
+import ResizeAware from 'ember-resize/mixins/resize-aware';
 import getOwner from 'ember-getowner-polyfill';
 
 const {
   computed,
   merge,
-  on
+  inject: {
+    service,
+  },
 } = Ember;
 
 /* global URI, ImgixClient */
 
-export default Ember.Mixin.create({
+export default Ember.Mixin.create(ResizeAware, {
+  resizeWidthSensitive: true,
+  resizeHeightSensitive: true,
+
   crossorigin: null,
   aspectRatio: null,
 
@@ -20,6 +26,8 @@ export default Ember.Mixin.create({
   pixelStep: 10,
 
   useParentWidth: false,
+
+  resizeService: service('resize'),
 
   /**
    * @public
@@ -106,7 +114,8 @@ export default Ember.Mixin.create({
   /**
    * Fire off a resize after our element has been added to the DOM.
    */
-  didInsertElement: function () {
+  didInsertElement: function (...args) {
+    this._super(...args);
     Ember.run.schedule('afterRender', this, this._incrementResizeCounter);
   },
 
@@ -114,14 +123,16 @@ export default Ember.Mixin.create({
    * Observer to trigger image resizes, but debounced.
    * @private
    */
-  _onResize: on('resize', function () {
+  didResize: function () {
     let debounceRate = 200;
     let env = this.get('_config');
     if (!!env && !!Ember.get(env, 'APP.imgix.debounceRate')) {
       debounceRate = Ember.get(env, 'APP.imgix.debounceRate');
     }
+
+    console.log(')(*$)(*$)(*$)(*$)(*$)(*$)(*$)');
     Ember.run.debounce(this, this._incrementResizeCounter, debounceRate);
-  }),
+  },
 
   /**
    * @property ImgixClient instantiated ImgixClient

--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -130,7 +130,6 @@ export default Ember.Mixin.create(ResizeAware, {
       debounceRate = Ember.get(env, 'APP.imgix.debounceRate');
     }
 
-    console.log(')(*$)(*$)(*$)(*$)(*$)(*$)(*$)');
     Ember.run.debounce(this, this._incrementResizeCounter, debounceRate);
   },
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.0",
     "ember-getowner-polyfill": "1.0.1",
-    "ember-resize-mixin": "kellysutton/ember-resize-mixin#master"
+    "ember-resize": "0.0.17"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/unit/components/imgix-image-test.js
+++ b/tests/unit/components/imgix-image-test.js
@@ -4,7 +4,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 
 moduleForComponent('imgix-image', 'Unit | Component | imgix image', {
   // Specify the other units that are required for this test
-  // needs: ['component:foo', 'helper:bar'],
+  needs: ['service:resize'],
   unit: true
 });
 


### PR DESCRIPTION
Update code to handle ember-resize
Remove double extend of `imgix-path-behavior` from components