### PR TITLE
chore(travis-config): update node versions to current

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
-  - "4.3.1"
-  - "5.7.0"
+  - "8"
+  - "10"
 
 sudo: false
 


### PR DESCRIPTION
This PR updates the node versions tested by Travis to current versions.
v8 = latest LTS node version
v10 = latest stable node version