### PR TITLE
feat: constrain precision of dpr to 2 decimal places

### DIFF
--- a/addon/common/index.js
+++ b/addon/common/index.js
@@ -1,0 +1,1 @@
+export * from './lib';

--- a/addon/common/lib.js
+++ b/addon/common/lib.js
@@ -1,0 +1,1 @@
+export const toFixed = (dp, value) => +value.toFixed(2);

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -7,6 +7,7 @@ import config from 'ember-get-config';
 import EmberError from '@ember/error';
 import ImgixClient from 'imgix-core-js';
 import { debounce } from '@ember/runloop';
+import { toFixed } from '../common';
 
 export default Component.extend(ResizeAware, {
   tagName: 'img',
@@ -45,7 +46,7 @@ export default Component.extend(ResizeAware, {
           ? newWidth / get(this, 'aspectRatio')
           : get(this, '_pathAsUrl.searchParams').get('h') || height
       );
-      const newDpr = window.devicePixelRatio || 1;
+      const newDpr = toFixed(2, window.devicePixelRatio || 1);
 
       set(this, '_width', newWidth);
       set(this, '_height', newHeight);

--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -6,6 +6,7 @@ import { getOwner } from '@ember/application';
 import EmberError from '@ember/error';
 import ImgixClient from 'imgix-core-js';
 import config from 'ember-get-config';
+import { toFixed } from '../common';
 
 export default Mixin.create({
   crossorigin: null,
@@ -239,7 +240,7 @@ export default Mixin.create({
    * @default 1
    */
   _dpr: computed('_resizeCounter', function() {
-    return window.devicePixelRatio || 1;
+    return toFixed(2, window.devicePixelRatio || 1);
   }),
 
   /**

--- a/tests/integration/components/imgix-image-wrapped-test.js
+++ b/tests/integration/components/imgix-image-wrapped-test.js
@@ -118,3 +118,16 @@ test('it allows setting the alt attribute', function(assert) {
   let alt = this.$('img').attr('alt');
   assert.equal(alt, 'User 1');
 });
+
+test('the dpr is constrained to a precision of 3', function(assert) {
+  const oldDpr = window.devicePixelRatio;
+  window.devicePixelRatio = 1.33333;
+
+  this.render(hbs`{{imgix-image-wrapped path="/users/1.png"}}`);
+
+  const url = new window.URL(this.$('img').attr('src'));
+
+  assert.equal(url.searchParams.get('dpr'), '1.33');
+
+  window.devicePixelRatio = oldDpr;
+});

--- a/tests/unit/components/imgix-image-test.js
+++ b/tests/unit/components/imgix-image-test.js
@@ -82,3 +82,20 @@ test('it respects the pixel step', function(assert) {
     )}`
   );
 });
+
+test('the dpr is constrained to a precision of 3', function(assert) {
+  const oldDpr = window.devicePixelRatio;
+  window.devicePixelRatio = 1.33333;
+
+  const component = this.subject();
+
+  setProperties(component, {
+    path: 'test.png'
+  });
+  component.didResize(100, 100);
+  const url = new window.URL(component.get('src'));
+
+  assert.equal(url.searchParams.get('dpr'), '1.33');
+
+  window.devicePixelRatio = oldDpr;
+});


### PR DESCRIPTION
## Description

Previously, `dpr` values were not rounded to a 2dp, which meant that some very specific dpr values were added to urls. This precision does not show any noticeable improvement in image quality, and is poor for image loading due to the rate of cache misses.

Now, `dpr` values are rounded to the nearest 2dp, which should improve image load performance.

Is it necessary to update the Readme for this behaviour?

This PR fixes #33 

### New Feature

- [N/A] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [N/A] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Review the changes to the unit tests.
