### PR TITLE
feat: change default crop behaviour to undefined from faces

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Some of the defaults are:
 ```javascript
 path: null, // The path to your image
 aspectRatio: null,
-crop: 'faces',
+crop: null,
 fit: 'crop',
 pixelStep: 10, // round to the nearest pixelStep
 onLoad: null,

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -15,7 +15,7 @@ export default Component.extend(ResizeAware, {
 
   path: null, // The path to your image
   aspectRatio: null,
-  crop: 'faces',
+  crop: null,
   fit: 'crop',
   pixelStep: 10,
   onLoad: null,
@@ -146,12 +146,15 @@ export default Component.extend(ResizeAware, {
       }
 
       let theseOptions = {
-        crop: get(this, 'crop'),
         fit: get(this, 'fit'),
         w: get(this, '_width'),
         h: get(this, '_height'),
         dpr: get(this, '_dpr')
       };
+
+      if (get(this, 'crop')) {
+        merge(theseOptions, { crop: get(this, 'crop') });
+      }
 
       merge(theseOptions, get(this, 'options'));
 

--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -94,9 +94,12 @@ export default Mixin.create({
       // These operations are defaults and should be overidden by any incoming
       // query parameters
       let options = {
-        crop: get(this, 'crop') || 'faces',
         fit: get(this, 'fit') || 'crop'
       };
+
+      if (get(this, 'crop')) {
+        merge(options, { crop: get(this, 'crop') });
+      }
 
       if (get(this, 'auto')) {
         merge(options, { auto: get(this, 'auto') });

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -47,7 +47,7 @@ test('it builds the default URL', function(assert) {
   assert.equal(url.searchParams.get('w'), '1250');
   assert.equal(url.pathname, '/users/1.png');
   assert.equal(url.searchParams.get('fit'), 'crop');
-  assert.equal(url.searchParams.get('crop'), 'faces');
+  assert.equal(url.searchParams.has('crop'), false);
 });
 
 test('it maintains any query parameters passed in', function(assert) {

--- a/tests/integration/components/imgix-image-wrapped-test.js
+++ b/tests/integration/components/imgix-image-wrapped-test.js
@@ -51,7 +51,7 @@ test('it builds the default URL', function(assert) {
   assert.equal(url.searchParams.get('w'), '1250');
   assert.equal(url.pathname, '/users/1.png');
   assert.equal(url.searchParams.get('fit'), 'crop');
-  assert.equal(url.searchParams.get('crop'), 'faces');
+  assert.equal(url.searchParams.has('crop'), false);
 });
 
 test('it maintains any query parameters passed in', function(assert) {

--- a/tests/unit/components/imgix-image-test.js
+++ b/tests/unit/components/imgix-image-test.js
@@ -47,7 +47,7 @@ test('it sets the source correctly', function(assert) {
   assert.equal(url.searchParams.get('w'), 400);
   assert.equal(url.searchParams.get('h'), 300);
   assert.ok(url.searchParams.get('dpr'));
-  assert.equal(url.searchParams.get('crop'), 'faces');
+  assert.equal(url.searchParams.has('crop'), false);
   assert.equal(url.searchParams.get('fit'), 'crop');
 });
 


### PR DESCRIPTION
BREAKING CHANGE: default crop behaviour is now imgix default, not `faces`

## Description

This PR removes the default setting for `crop`. The old behaviour may be confusing to new developers, so it is better for them to enable it if they would like the behaviour.

This PR fixes #34 

### New Feature

- [N/A] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Review the changes to the tests.