### PR TITLE
feat: disable tests for ember v3.3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
-      "ember": ">2.15.0"
+      "ember": ">2.15.0 <3.0.0"
     }
   }
 }


### PR DESCRIPTION
## Description

Ember-try is encountering unknown issues when trying to test Ember v3.3, so it's best that this version be disabled for now. I've created an issue reminding us to enable this in the future at #46


