### PR TITLE
[feature](attribute bindings): Adds attribute bindings for draggable attribute (and tests for the other attribute bindings crossorigin & alt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ fit: 'crop',
 pixelStep: 10, // round to the nearest pixelStep
 onLoad: null,
 onError: null,
-crossorigin: 'anonymous',
-alt: '', // image alt
+crossorigin: 'anonymous', // img element crossorigin attr
+alt: '', // img element alt attr
+draggable: true, // img element draggable attr
 options: {}, // arbitrary imgix options
 auto: null, // https://docs.imgix.com/apis/url/auto
 

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -12,7 +12,12 @@ import { toFixed, constants } from '../common';
 export default Component.extend(ResizeAware, {
   tagName: 'img',
   classNames: 'imgix-image',
-  attributeBindings: ['src', 'crossorigin', 'alt'],
+  attributeBindings: [
+    'alt',
+    'crossorigin',
+    'draggable',
+    'src', 
+  ],
 
   path: null, // The path to your image
   aspectRatio: null,
@@ -21,8 +26,9 @@ export default Component.extend(ResizeAware, {
   pixelStep: 10,
   onLoad: null,
   onError: null,
-  crossorigin: 'anonymous',
-  alt: '', // image alt
+  crossorigin: 'anonymous', // img element crossorigin attr
+  alt: '', // img element alt attr
+  draggable: true, // img element draggable attr
   options: {}, // arbitrary imgix options
   disableLibraryParam: false,
 

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -137,3 +137,22 @@ test('attribute bindings: the draggable argument will set the draggable attribut
   assert.equal(this.$('img').attr('draggable'), 'false');
 });
 
+test('attribute bindings: the crossorigin argument will set the crossorigin attribute on the image element', function(assert) {
+  assert.expect(1);
+
+  this.render(
+    hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png' crossorigin='imgix-is-rad'}}</div>`
+  );
+
+  assert.equal(this.$('img').attr('crossorigin'), 'imgix-is-rad');
+});
+
+test('attribute bindings: the alt argument will set the alt attribute on the image element', function(assert) {
+  assert.expect(1);
+
+  this.render(
+    hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png' alt='Photo of User 1'}}</div>`
+  );
+
+  assert.equal(this.$('img').attr('alt'), 'Photo of User 1');
+});

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -126,3 +126,14 @@ test('it allows passing ANY imgix parameter as an option hash', function(assert)
   assert.equal(uri.getQueryParamValue('exp'), 20);
   assert.equal(uri.getQueryParamValue('invert'), 'true');
 });
+
+test('attribute bindings: the draggable argument will set the draggable attribute on the image element', function(assert) {
+  assert.expect(1);
+
+  this.render(
+    hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png' draggable=false}}</div>`
+  );
+
+  assert.equal(this.$('img').attr('draggable'), 'false');
+});
+


### PR DESCRIPTION
- Adds attribute bindings for the html `draggable` attribute available on img elements.
- Adds tests for ^ and additional tests for the other attribute bindings we support.
- Updates the readme with the new draggable argument.

To use the draggable attribute binding: 

```handlebars
{{imgix-img
    path='/assets/something/user.png'
    draggable=false
}}
```
Outputs:
```html
<img draggable='false' src='https://somewhere.overtherainbow/assets/something/user.png?width=10&height=10...etc'>
```