### PR TITLE
feat: implement responsiveness with srcSet and sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Since imgix can generate as many derivative resolutions as needed, ember-cli-img
 **Width and height known:** If the width and height are known beforehand, it is recommended that they are set explicitly:
 
 ```hbs
-{{imgix-image path='/users/1.png' sizes='100vw' width=100 height=100}}
+{{imgix-image path='/users/1.png' width=100 height=100}}
 ```
 
 NB: Since this library sets [`fit`](https://docs.imgix.com/apis/url/size/fit) to `crop` by default, when just a width or height is set, the image will resize and maintain aspect ratio. When both are set, the image will be cropped to that size, maintaining pixel aspect ratio (i.e. edges are clipped in order to not stretch the photo). If this isn't desired, set `fit` to be another value (e.g. `clip`)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ crossorigin: 'anonymous', // img element crossorigin attr
 alt: '', // img element alt attr
 draggable: true, // img element draggable attr
 options: {}, // arbitrary imgix options
-auto: null, // https://docs.imgix.com/apis/url/auto
 
 width: null, // override if you want to hardcode a width into the image
 height: null, // override if you want to hardcode a height into the image

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ onError: null,
 crossorigin: 'anonymous', // img element crossorigin attr
 alt: '', // img element alt attr
 draggable: true, // img element draggable attr
+disableSrcSet: false, // disable srcSet generation
 options: {}, // arbitrary imgix options
 
 width: null, // override if you want to hardcode a width into the image

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ An Ember addon for easily adding responsive imagery via [imgix](https://www.imgi
 
 **Note:** Front-end imgix libraries and framework integrations will not work with imgix Web Proxy Sources. They will only work with imgix Web Folder or S3 Sources.
 
+## Overview / Resources
+
+**Before you get started with ember-cli-imgix**, it's _highly recommended_ that you read Eric Portis' [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/). This article explains the history of responsive images in responsive design, why they're necessary, and how all these technologies work together to save bandwidth and provide a better experience for users. The primary goal of react-imgix is to make these tools easier for developers to implement, so having an understanding of how they work will significantly improve your ember-cli-imgix experience.
+
+Below are some other articles that help explain responsive imagery, and how it can work alongside imgix:
+
+- [Responsive Images with `srcset` and imgix](https://docs.imgix.com/tutorials/responsive-images-srcset-imgix). A look into how imgix can work with `srcset` and `sizes` to serve the right image.
+
 ## Installation
 
 From within an existing ember-cli project:
@@ -42,18 +50,33 @@ module.exports = function(environment) {
 `ember-cli-imgix` exposes a `img` element with expanded functionality. It simply renders an `img`, but has some extra parameters
 
 ```hbs
-{{imgix-image path='/users/1.png'}}
+{{imgix-image path='/users/1.png' sizes='100vw'}}
 ```
 
 Which will generate some HTML similar to this:
 
 ```html
-<img class="imgix-image" src="https://my-social-network.com/users/1.png?w=400&h=300&dpr=1" >
+<img
+  class="imgix-image"
+  src="https://my-social-network.com/users/1.png"
+  sizes="100vw"
+  srcset="https://my-social-network.com/users/1.png?w=100 100w, https://my-social-network.com/users/1.png?w=200 200w, ..."
+/>
 ```
 
 The src attribute will have imgix URL API parameters added to it to perform the resize.
 
-**Note:** This element works by calculating the width/height from its parent. If its parent has no width/height, then this component will do nothing.
+**Please note:** `100vw` is an appropriate `sizes` value for a full-bleed image. If your image is not full-bleed, you should use a different value for `sizes`. [Eric Portis' "Srcset and sizes"](https://ericportis.com/posts/2014/srcset-sizes/) article goes into depth on how to use the `sizes` attribute.
+
+Since imgix can generate as many derivative resolutions as needed, react-imgix calculates them programmatically, using the dimensions you specify. All of this information has been placed into the srcset and sizes attributes.
+
+**Width and height known:** If the width and height are known beforehand, it is recommended that they are set explicitly:
+
+```hbs
+{{imgix-image path='/users/1.png' sizes='100vw' width=100 height=100}}
+```
+
+NB: Since this library sets [`fit`](https://docs.imgix.com/apis/url/size/fit) to `crop` by default, when just a width or height is set, the image will resize and maintain aspect ratio. When both are set, the image will be cropped to that size, maintaining pixel aspect ratio (i.e. edges are clipped in order to not stretch the photo). If this isn't desired, set `fit` to be another value (e.g. `clip`)
 
 #### Parameters
 
@@ -66,7 +89,6 @@ path: null, // The path to your image
 aspectRatio: null,
 crop: null,
 fit: 'crop',
-pixelStep: 10, // round to the nearest pixelStep
 onLoad: null,
 onError: null,
 crossorigin: 'anonymous', // img element crossorigin attr
@@ -183,6 +205,17 @@ import ImgixCoreJs from 'imgix-core-js';
 `imgix-image` has been replaced by a new implementation of `imgix-image-element`. All usage of `imgix-image-element` can be replaced with `imgix-image`. No parameter changes are necessary.
 
 `imgix-image` has been renamed to `imgix-image-wrapped` and has been deprecated. All usage of `imgix-image` can be replaced with `imgix-image-wrapped` for the duration of version 2. No parameter changes are necessary. After version 2, `imgix-image-wrapped` will not exist.
+
+## version 1.x to version 2.x
+
+The largest change in this major version bump is the move to width-based `srcSet` and `sizes` for responsiveness. This has a host of benefits, including better server rendering, better responsiveness, less potential for bugs, and perfomance improvements.
+
+- A `sizes` prop should be added to all usages of ember-cli-imgix. If `sizes` is new to you (or even if it's not), Eric's [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/) is highly recommended.
+
+## Browser Support
+
+- By default, browsers that don't support [`srcset`](http://caniuse.com/#feat=srcset), [`sizes`](http://caniuse.com/#feat=srcset), or [`picture`](http://caniuse.com/#feat=picture) will gracefully fall back to the default `img` `src` when appropriate. If you want to provide a fully-responsive experience for these browsers, react-imgix works great alongside [Picturefill](https://github.com/scottjehl/picturefill)!
+- We support the latest version of Google Chrome (which [automatically updates](https://support.google.com/chrome/answer/95414) whenever it detects that a new version of the browser is available). We also support the current and previous major releases of desktop Firefox, Internet Explorer, and Safari on a rolling basis. Mobile support is tested on the most recent minor version of the current and previous major release for the default browser on iOS and Android (e.g., iOS 9.2 and 8.4). Each time a new version is released, we begin supporting that version and stop supporting the third most recent version.
 
 ## Running a test app
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Ember addon for easily adding responsive imagery via [imgix](https://www.imgi
 
 ## Overview / Resources
 
-**Before you get started with ember-cli-imgix**, it's _highly recommended_ that you read Eric Portis' [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/). This article explains the history of responsive images in responsive design, why they're necessary, and how all these technologies work together to save bandwidth and provide a better experience for users. The primary goal of react-imgix is to make these tools easier for developers to implement, so having an understanding of how they work will significantly improve your ember-cli-imgix experience.
+**Before you get started with ember-cli-imgix**, it's _highly recommended_ that you read Eric Portis' [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/). This article explains the history of responsive images in responsive design, why they're necessary, and how all these technologies work together to save bandwidth and provide a better experience for users. The primary goal of ember-cli-imgix is to make these tools easier for developers to implement, so having an understanding of how they work will significantly improve your ember-cli-imgix experience.
 
 Below are some other articles that help explain responsive imagery, and how it can work alongside imgix:
 
@@ -68,7 +68,7 @@ The src attribute will have imgix URL API parameters added to it to perform the 
 
 **Please note:** `100vw` is an appropriate `sizes` value for a full-bleed image. If your image is not full-bleed, you should use a different value for `sizes`. [Eric Portis' "Srcset and sizes"](https://ericportis.com/posts/2014/srcset-sizes/) article goes into depth on how to use the `sizes` attribute.
 
-Since imgix can generate as many derivative resolutions as needed, react-imgix calculates them programmatically, using the dimensions you specify. All of this information has been placed into the srcset and sizes attributes.
+Since imgix can generate as many derivative resolutions as needed, ember-cli-imgix calculates them programmatically, using the dimensions you specify. All of this information has been placed into the srcset and sizes attributes.
 
 **Width and height known:** If the width and height are known beforehand, it is recommended that they are set explicitly:
 
@@ -213,7 +213,7 @@ The largest change in this major version bump is the move to width-based `srcSet
 
 ## Browser Support
 
-- By default, browsers that don't support [`srcset`](http://caniuse.com/#feat=srcset), [`sizes`](http://caniuse.com/#feat=srcset), or [`picture`](http://caniuse.com/#feat=picture) will gracefully fall back to the default `img` `src` when appropriate. If you want to provide a fully-responsive experience for these browsers, react-imgix works great alongside [Picturefill](https://github.com/scottjehl/picturefill)!
+- By default, browsers that don't support [`srcset`](http://caniuse.com/#feat=srcset), [`sizes`](http://caniuse.com/#feat=srcset), or [`picture`](http://caniuse.com/#feat=picture) will gracefully fall back to the default `img` `src` when appropriate. If you want to provide a fully-responsive experience for these browsers, ember-cli-imgix works great alongside [Picturefill](https://github.com/scottjehl/picturefill)!
 - We support the latest version of Google Chrome (which [automatically updates](https://support.google.com/chrome/answer/95414) whenever it detects that a new version of the browser is available). We also support the current and previous major releases of desktop Firefox, Internet Explorer, and Safari on a rolling basis. Mobile support is tested on the most recent minor version of the current and previous major release for the default browser on iOS and Android (e.g., iOS 9.2 and 8.4). Each time a new version is released, we begin supporting that version and stop supporting the third most recent version.
 
 ## Running a test app

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ import ImgixCoreJs from 'imgix-core-js';
 
 The largest change in this major version bump is the move to width-based `srcSet` and `sizes` for responsiveness. This has a host of benefits, including better server rendering, better responsiveness, less potential for bugs, and perfomance improvements.
 
-- A `sizes` prop should be added to all usages of ember-cli-imgix. If `sizes` is new to you (or even if it's not), Eric's [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/) is highly recommended.
+- A `sizes` prop should be added to all usages of ember-cli-imgix, unless the width or height of the image are known beforehand (see above). If `sizes` is new to you (or even if it's not), Eric's [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/) is highly recommended.
 
 ## Browser Support
 

--- a/addon/common/index.js
+++ b/addon/common/index.js
@@ -1,4 +1,5 @@
 export * from './lib';
+export { default as targetWidths } from './targetWidths';
 import constants from './constants';
 
 export { constants };

--- a/addon/common/targetWidths.js
+++ b/addon/common/targetWidths.js
@@ -1,0 +1,18 @@
+function targetWidths() {
+  const resolutions = [];
+  let prev = 100;
+  const INCREMENT_PERCENTAGE = 8;
+  const MAX_SIZE = 8192;
+
+  const ensureEven = n => 2 * Math.round(n / 2);
+
+  resolutions.push(prev);
+  while (prev <= MAX_SIZE) {
+    prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
+    resolutions.push(ensureEven(prev));
+  }
+
+  return resolutions;
+}
+
+export default targetWidths();

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -123,6 +123,8 @@ export default Component.extend({
         theseOptions.h = height;
       }
 
+      const fixedDimensions = width != null || height != null;
+
       if (get(this, 'crop')) {
         theseOptions.crop = get(this, 'crop');
       }
@@ -145,15 +147,24 @@ export default Component.extend({
       let srcSet = undefined;
       const disableSrcSet = get(this, 'disableSrcSet');
       if (!disableSrcSet) {
-        const buildSrcSetPair = targetWidth => {
-          const url = buildWithOptions({
-            ...options,
-            w: targetWidth
-          });
-          return `${url} ${targetWidth}w`;
-        };
-        const addFallbackSrc = srcSet => srcSet.concat(src);
-        srcSet = addFallbackSrc(targetWidths.map(buildSrcSetPair)).join(', ');
+        if (fixedDimensions) {
+          const buildWithDpr = dpr =>
+            buildWithOptions({
+              ...options,
+              dpr
+            });
+          srcSet = `${buildWithDpr(2)} 2x, ${buildWithDpr(3)} 3x`;
+        } else {
+          const buildSrcSetPair = targetWidth => {
+            const url = buildWithOptions({
+              ...options,
+              w: targetWidth
+            });
+            return `${url} ${targetWidth}w`;
+          };
+          const addFallbackSrc = srcSet => srcSet.concat(src);
+          srcSet = addFallbackSrc(targetWidths.map(buildSrcSetPair)).join(', ');
+        }
       }
 
       return { src, srcSet };

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -53,10 +53,6 @@ export default Component.extend({
     }
   },
 
-  didUpdateAttrs(...args) {
-    this._super(...args);
-  },
-
   willDestroyElement(...args) {
     if (get(this, 'onLoad') && typeof FastBoot === 'undefined') {
       this.element.removeEventListener('load', this._handleImageLoad);

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -11,7 +11,7 @@ import { constants, targetWidths } from '../common';
 export default Component.extend({
   tagName: 'img',
   classNames: 'imgix-image',
-  attributeBindings: ['src', 'srcSet', 'crossorigin', 'alt'],
+  attributeBindings: ['src', 'srcSet', 'crossorigin', 'alt', 'sizes'],
 
   path: null, // The path to your image
   aspectRatio: null,

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -153,7 +153,8 @@ export default Component.extend({
               ...options,
               dpr
             });
-          srcSet = `${buildWithDpr(2)} 2x, ${buildWithDpr(3)} 3x`;
+          // prettier-ignore
+          srcSet = `${buildWithDpr(2)} 2x, ${buildWithDpr(3)} 3x, ${buildWithDpr(4)} 4x, ${buildWithDpr(5)} 5x`;
         } else {
           const buildSrcSetPair = targetWidth => {
             const url = buildWithOptions({

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -1,24 +1,22 @@
 import Component from '@ember/component';
-import { computed, get, set } from '@ember/object';
-import ResizeAware from 'ember-resize-aware/mixins/resize-aware';
+import { computed, get } from '@ember/object';
 import { tryInvoke } from '@ember/utils';
 import config from 'ember-get-config';
 import EmberError from '@ember/error';
 import ImgixClient from 'imgix-core-js';
 import URI from 'jsuri';
 import { debounce } from '@ember/runloop';
-import { toFixed, constants } from '../common';
+import { constants, targetWidths } from '../common';
 
-export default Component.extend(ResizeAware, {
+export default Component.extend({
   tagName: 'img',
   classNames: 'imgix-image',
-  attributeBindings: ['src', 'crossorigin', 'alt'],
+  attributeBindings: ['src', 'srcSet', 'crossorigin', 'alt'],
 
   path: null, // The path to your image
   aspectRatio: null,
   crop: null,
   fit: 'crop',
-  pixelStep: 10,
   onLoad: null,
   onError: null,
   crossorigin: 'anonymous',
@@ -26,34 +24,12 @@ export default Component.extend(ResizeAware, {
   options: {}, // arbitrary imgix options
   disableLibraryParam: false,
 
-  width: null, // passed in
-  height: null, // passed in
-
-  _width: null,
-  _height: null,
-  _dpr: null,
+  width: null,
+  height: null,
+  sizes: null,
+  disableSrcSet: false,
 
   debounceRate: 400,
-
-  didResize(width, height) {
-    if (get(this, 'path')) {
-      const newWidth =
-        Math.ceil(
-          get(this, '_pathAsUri').getQueryParamValue('w') ||
-            width / get(this, 'pixelStep')
-        ) * get(this, 'pixelStep');
-      const newHeight = Math.floor(
-        get(this, 'aspectRatio')
-          ? newWidth / get(this, 'aspectRatio')
-          : get(this, '_pathAsUri').getQueryParamValue('h') || height
-      );
-      const newDpr = toFixed(2, window.devicePixelRatio || 1);
-
-      set(this, '_width', newWidth);
-      set(this, '_height', newHeight);
-      set(this, '_dpr', newDpr);
-    }
-  },
 
   didInsertElement(...args) {
     this._super(...args);
@@ -67,34 +43,10 @@ export default Component.extend(ResizeAware, {
       this._handleImageError = this._handleImageError.bind(this);
       this.element.addEventListener('error', this._handleImageError);
     }
-
-    this.didResize(
-      get(this, 'width') ||
-        get(this, '_width') ||
-        this.element.clientWidth ||
-        this.element.parentElement.clientWidth,
-      get(this, 'height') ||
-        get(this, '_height') ||
-        this.element.clientHeight ||
-        this.element.parentElement.clientHeight
-    );
   },
 
   didUpdateAttrs(...args) {
     this._super(...args);
-
-    if (typeof FastBoot === 'undefined') {
-      this.didResize(
-        get(this, 'width') ||
-          get(this, '_width') ||
-          this.element.clientWidth ||
-          this.element.parentElement.clientWidth,
-        get(this, 'height') ||
-          get(this, '_height') ||
-          this.element.clientHeight ||
-          this.element.parentElement.clientHeight
-      );
-    }
   },
 
   willDestroyElement(...args) {
@@ -137,31 +89,35 @@ export default Component.extend(ResizeAware, {
     });
   }),
 
-  src: computed(
+  _srcAndSrcSet: computed(
     'path',
     '_pathAsUri',
-    '_width',
-    '_height',
-    '_dpr',
+    'width',
+    'height',
     'crop',
     'fit',
+    'disableSrcSet',
     function() {
       const pathAsUri = get(this, '_pathAsUri');
-      const debugParams = get(config, 'APP.imgix.debug') ? get(this, '_debugParams') : {};
+      const debugParams = get(config, 'APP.imgix.debug')
+        ? get(this, '_debugParams')
+        : {};
 
-      if (!get(this, '_width')) {
-        return;
-      }
       if (!get(this, 'path')) {
         return;
       }
 
       let theseOptions = {
-        dpr: get(this, '_dpr'),
-        fit: get(this, 'fit'),
-        h: get(this, '_height'),
-        w: get(this, '_width'),
+        fit: get(this, 'fit')
       };
+      const width = get(this, 'width');
+      if (width != null) {
+        theseOptions.w = width;
+      }
+      const height = get(this, 'height');
+      if (height != null) {
+        theseOptions.h = height;
+      }
 
       if (get(this, 'crop')) {
         theseOptions.crop = get(this, 'crop');
@@ -174,15 +130,38 @@ export default Component.extend(ResizeAware, {
         ...pathAsUri.queryPairs.reduce((memo, param) => {
           memo[param[0]] = param[1];
           return memo;
-        }, {}),
+        }, {})
       };
 
-      return get(this, '_client').buildURL(
-        get(this, '_pathAsUri').path(),
-        options
-      );
+      const client = get(this, '_client');
+      const buildWithOptions = options =>
+        client.buildURL(pathAsUri.path(), options);
+      const src = buildWithOptions(options);
+
+      let srcSet = undefined;
+      const disableSrcSet = get(this, 'disableSrcSet');
+      if (!disableSrcSet) {
+        const buildSrcSetPair = targetWidth => {
+          const url = buildWithOptions({
+            ...options,
+            w: targetWidth
+          });
+          return `${url} ${targetWidth}w`;
+        };
+        const addFallbackSrc = srcSet => srcSet.concat(src);
+        srcSet = addFallbackSrc(targetWidths.map(buildSrcSetPair)).join(', ');
+      }
+
+      return { src, srcSet };
     }
   ),
+
+  src: computed('_srcAndSrcSet', function() {
+    return get(this, '_srcAndSrcSet.src');
+  }),
+  srcSet: computed('_srcAndSrcSet', function() {
+    return get(this, '_srcAndSrcSet.srcSet');
+  }),
 
   _handleImageLoad(event) {
     debounce(
@@ -200,12 +179,14 @@ export default Component.extend(ResizeAware, {
     );
   },
 
-  _debugParams: computed('_width', '_height', '_dpr', function() {
+  _debugParams: computed('width', 'height', function() {
+    const width = get(this, 'width');
+    const height = get(this, 'height');
+
     return {
-      txt64: `${get(this, '_width')} x ${get(this, '_height')} @ DPR ${get(
-        this,
-        '_dpr'
-      )}`,
+      txt64: `${width != null ? width : 'auto'} x ${
+        height != null ? height : 'auto'
+      }`,
       txtalign: 'center,bottom',
       txtsize: 20,
       txtfont: 'Helvetica Neue',

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -1,3 +1,5 @@
+/* global QUnit */
+
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import URI from 'jsuri';
@@ -27,41 +29,35 @@ test('it renders event more better', function(assert) {
 });
 
 test('it renders the correct path', function(assert) {
-  this.render(hbs`<div style='width:1250px;height:200px;'>{{imgix-image path="/users/1.png"}}</div>`);
+  this.render(hbs`<div>{{imgix-image path="/users/1.png"}}</div>`);
 
   assert.ok(
     this.$('img')
       .attr('src')
       .indexOf('https://assets.imgix.net/users/1.png') > -1
   );
-  assert.ok(
-    this.$('img')
-      .attr('src')
-      .indexOf('w=1250') > -1
-  );
 });
 
 test('it builds the default URL', function(assert) {
-  this.render(hbs`<div style='width:1250px;height:200px;'>{{imgix-image path="/users/1.png"}}</div>`);
+  this.render(hbs`<div>{{imgix-image path="/users/1.png"}}</div>`);
   let uri = new URI(this.$('img').attr('src'));
 
-  assert.equal(uri.getQueryParamValue('w'), '1250');
   assert.equal(uri.path(), '/users/1.png');
   assert.equal(uri.getQueryParamValue('fit'), 'crop');
   assert.equal(uri.hasQueryParam('crop'), false);
 });
 
 test('it maintains any query parameters passed in', function(assert) {
-  assert.expect(2);
-  this.render(hbs`<div style='width:1250px;height:200px;'>{{imgix-image path="/users/1.png?sat=100"}}</div>`);
+  this.render(hbs`<div>{{imgix-image path="/users/1.png?sat=100"}}</div>`);
 
   let uri = new URI(this.$('img').attr('src'));
   assert.equal(uri.getQueryParamValue('sat'), '100');
-  assert.equal(uri.getQueryParamValue('w'), '1250');
 });
 
-test('it renders with an aspect ratio', function(assert) {
-  this.render(hbs`<div style='width:1250px;'>{{imgix-image path="/users/1.png" aspectRatio=1.3333}}</div>`);
+QUnit.skip('it renders with an aspect ratio', function(assert) {
+  this.render(
+    hbs`<div>{{imgix-image path="/users/1.png" aspectRatio=1.3333}}</div>`
+  );
 
   assert.equal(
     this.$()
@@ -118,7 +114,7 @@ test('it allows setting the alt attribute', function(assert) {
 test('it allows passing ANY imgix parameter as an option hash', function(assert) {
   assert.expect(2);
   this.render(
-    hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png' options=(hash exp=20 invert=true)}}</div>`
+    hbs`<div>{{imgix-image path='/users/1.png' options=(hash exp=20 invert=true)}}</div>`
   );
 
   let uri = new URI(this.$('img').attr('src'));

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -65,7 +65,16 @@ QUnit.skip('it renders with an aspect ratio', function(assert) {
   assert.equal(uri.getQueryParamValue('h'), '937');
 });
 
-test('it respects passed in `crop` and `fit` values', function(assert) {
+test(`it respects the width and height passed in`, function(assert) {
+  this.render(hbs`{{imgix-image path="/users/1.png" width=100 height=200}}`);
+
+  expectSrcsTo(this.$, (_, uri) => {
+    assert.equal(uri.getQueryParamValue('w'), '100');
+    assert.equal(uri.getQueryParamValue('h'), '200');
+  });
+});
+
+test(`it respects passed in 'crop' and 'fit' values`, function(assert) {
   this.render(
     hbs`{{imgix-image path="/users/1.png?sat=100&fit=min&crop=top,left"}}`
   );

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -3,55 +3,48 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import URI from 'jsuri';
+import config from 'ember-get-config';
 
 moduleForComponent('imgix-image', 'Integration | Component | imgix image', {
   integration: true
 });
 
-test('it renders', function(assert) {
+test('it renders an image', function(assert) {
   this.render(hbs`{{imgix-image path="/users/1.png"}}`);
-  assert.ok(this.$());
+  assert.ok(this.$('img'));
 });
 
-test('it renders event more better', function(assert) {
-  this.render(
-    hbs`<div style='width:200px;height:200px;'>{{imgix-image path='/users/1.png' }}</div>`
-  );
-
-  let uri = new URI(this.$('img').attr('src'));
-  assert.equal(
-    this.$()
-      .text()
-      .trim(),
-    ''
-  );
-  assert.equal(uri.path(), '/users/1.png');
-});
-
-test('it renders the correct path', function(assert) {
+test(`the rendered image's srcs have the correct path`, function(assert) {
   this.render(hbs`<div>{{imgix-image path="/users/1.png"}}</div>`);
 
-  assert.ok(
-    this.$('img')
-      .attr('src')
-      .indexOf('https://assets.imgix.net/users/1.png') > -1
-  );
+  expectSrcsTo(this.$, (_, uri) => {
+    assert.equal(uri.path(), '/users/1.png');
+  });
 });
 
-test('it builds the default URL', function(assert) {
+test(`the rendered image's srcs have the correct host`, function(assert) {
   this.render(hbs`<div>{{imgix-image path="/users/1.png"}}</div>`);
-  let uri = new URI(this.$('img').attr('src'));
 
-  assert.equal(uri.path(), '/users/1.png');
-  assert.equal(uri.getQueryParamValue('fit'), 'crop');
-  assert.equal(uri.hasQueryParam('crop'), false);
+  expectSrcsTo(this.$, (_, uri) => {
+    assert.equal(config.APP.imgix.source, uri.host());
+    assert.equal('https', uri.protocol());
+  });
 });
 
-test('it maintains any query parameters passed in', function(assert) {
+test(`the image's srcs have the fit parameter set to crop by default`, function(assert) {
+  this.render(hbs`<div>{{imgix-image path="/users/1.png"}}</div>`);
+
+  expectSrcsTo(this.$, (_, uri) => {
+    assert.equal(uri.getQueryParamValue('fit'), 'crop');
+  });
+});
+
+test(`the image's srcs contains an query parameters passed in via the 'path' attribute`, function(assert) {
   this.render(hbs`<div>{{imgix-image path="/users/1.png?sat=100"}}</div>`);
 
-  let uri = new URI(this.$('img').attr('src'));
-  assert.equal(uri.getQueryParamValue('sat'), '100');
+  expectSrcsTo(this.$, (_, uri) => {
+    assert.equal(uri.getQueryParamValue('sat'), '100');
+  });
 });
 
 QUnit.skip('it renders with an aspect ratio', function(assert) {
@@ -73,59 +66,46 @@ QUnit.skip('it renders with an aspect ratio', function(assert) {
 });
 
 test('it respects passed in `crop` and `fit` values', function(assert) {
-  assert.expect(2);
   this.render(
     hbs`{{imgix-image path="/users/1.png?sat=100&fit=min&crop=top,left"}}`
   );
 
-  let uri = new URI(this.$('img').attr('src'));
-  assert.equal(uri.getQueryParamValue('fit'), 'min');
-  assert.equal(uri.getQueryParamValue('crop'), 'top,left');
+  expectSrcsTo(this.$, (_, uri) => {
+    assert.equal(uri.getQueryParamValue('fit'), 'min');
+    assert.equal(uri.getQueryParamValue('crop'), 'top,left');
+  });
 });
 
-test('it respects `crop` and `fit` values passed as attributes', function(assert) {
-  assert.expect(2);
+test(`it respects 'crop' and 'fit' values passed as attributes`, function(assert) {
   this.render(
     hbs`{{imgix-image path="/users/1.png" crop="top,left" fit="min"}}`
   );
 
-  let uri = new URI(this.$('img').attr('src'));
-  assert.equal(uri.getQueryParamValue('crop'), 'top,left');
-  assert.equal(uri.getQueryParamValue('fit'), 'min');
+  expectSrcsTo(this.$, (_, uri) => {
+    assert.equal(uri.getQueryParamValue('fit'), 'min');
+    assert.equal(uri.getQueryParamValue('crop'), 'top,left');
+  });
 });
 
-test('it respects `auto` values passed as attributes', function(assert) {
-  assert.expect(1);
-  this.render(
-    hbs`{{imgix-image-wrapped path="/users/1.png" auto="compress,enhance"}}`
-  );
-
-  let uri = new URI(this.$('img').attr('src'));
-  assert.equal(uri.getQueryParamValue('auto'), 'compress,enhance');
-});
-
-test('it allows setting the alt attribute', function(assert) {
+test(`it allows setting the 'alt' attribute`, function(assert) {
   this.render(hbs`{{imgix-image path="/users/1.png" alt="User 1"}}`);
+  const alt = this.$('img').attr('alt');
 
-  let alt = this.$('img').attr('alt');
   assert.equal(alt, 'User 1');
 });
 
 test('it allows passing ANY imgix parameter as an option hash', function(assert) {
-  assert.expect(2);
   this.render(
     hbs`<div>{{imgix-image path='/users/1.png' options=(hash exp=20 invert=true)}}</div>`
   );
 
-  let uri = new URI(this.$('img').attr('src'));
-
-  assert.equal(uri.getQueryParamValue('exp'), 20);
-  assert.equal(uri.getQueryParamValue('invert'), 'true');
+  expectSrcsTo(this.$, (_, uri) => {
+    assert.equal(uri.getQueryParamValue('exp'), 20);
+    assert.equal(uri.getQueryParamValue('invert'), 'true');
+  });
 });
 
 test('attribute bindings: the draggable argument will set the draggable attribute on the image element', function(assert) {
-  assert.expect(1);
-
   this.render(
     hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png' draggable=false}}</div>`
   );
@@ -143,12 +123,18 @@ test('attribute bindings: the crossorigin argument will set the crossorigin attr
   assert.equal(this.$('img').attr('crossorigin'), 'imgix-is-rad');
 });
 
-test('attribute bindings: the alt argument will set the alt attribute on the image element', function(assert) {
-  assert.expect(1);
+// matcher should be in the form (url: string, uri: URI) => boolean
+function expectSrcsTo($, matcher) {
+  const src = $('img').attr('src');
+  matcher(src, new URI(src));
 
-  this.render(
-    hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png' alt='Photo of User 1'}}</div>`
-  );
-
-  assert.equal(this.$('img').attr('alt'), 'Photo of User 1');
-});
+  const srcSet = $('img').attr('srcset');
+  if (!srcSet) {
+    throw new Error("srcSet doesn't exist");
+  }
+  const srcSets = srcSet.split(',').map(v => v.trim());
+  const srcSetUrls = srcSets.map(srcSet => srcSet.split(' ')[0]);
+  srcSetUrls.forEach(srcSetUrl => {
+    matcher(srcSetUrl, new URI(srcSetUrl));
+  });
+}

--- a/tests/unit/components/imgix-image-test.js
+++ b/tests/unit/components/imgix-image-test.js
@@ -15,6 +15,36 @@ test('it does not throw an exception when given an undefined path', function(ass
   assert.equal(component._state, 'inDOM');
 });
 
+test('the generated img has a srcSet in the format of 2x, 3x when passing a fixed width', function(assert) {
+  const component = this.subject();
+  setProperties(component, {
+    path: '/users/1.png',
+    width: 100
+  });
+
+  const srcSet = component.get('srcSet');
+  const actualNumberOfSrcSets = srcSet.split(', ').length;
+  assert.equal(actualNumberOfSrcSets, 2);
+  srcSet.split(', ').forEach(srcSet => {
+    assert.ok(srcSet.split(' ')[1].match(/^\dx$/));
+  });
+});
+
+test('the generated img has a srcSet in the format of 2x, 3x when passing a fixed height', function(assert) {
+  const component = this.subject();
+  setProperties(component, {
+    path: '/users/1.png',
+    height: 100
+  });
+
+  const srcSet = component.get('srcSet');
+  const actualNumberOfSrcSets = srcSet.split(', ').length;
+  assert.equal(actualNumberOfSrcSets, 2);
+  srcSet.split(', ').forEach(srcSet => {
+    assert.ok(srcSet.split(' ')[1].match(/^\dx$/));
+  });
+});
+
 test('the generated img has the correct number of srcSets', function(assert) {
   const expectedNumberOfSrcSets = 32;
 
@@ -48,6 +78,17 @@ test('the generated img has srcSets in the correct format', function(assert) {
   const fallbackSrcSet = srcSets[srcSets.length - 1];
   assert.equal(fallbackSrcSet.split(' ').length, 1);
   assert.notOk(fallbackSrcSet.match(/^\d+w$/));
+});
+
+test('the generated img should not contain a srcSet when disableSrcSet is set', function(assert) {
+  const component = this.subject();
+  setProperties(component, {
+    path: '/users/1.png',
+    disableSrcSet: true
+  });
+
+  const srcSet = component.get('srcSet');
+  assert.notOk(srcSet);
 });
 
 test('the generated src url has an ixlib parameter', function(assert) {
@@ -87,19 +128,3 @@ test('setting disableLibraryParam in the global config should cause the url not 
 
   config.APP.imgix.disableLibraryParam = oldDisableLibraryParam;
 });
-
-// matcher should be in the form (url: string, uri: URI) => boolean
-function expectSrcsTo(component, matcher) {
-  const src = component.get('src');
-  matcher(src, new URI(src));
-
-  const srcSet = component.get('srcset');
-  if (!srcSet) {
-    throw new Error("srcSet doesn't exist");
-  }
-  const srcSets = srcSet.split(',').map(v => v.trim());
-  const srcSetUrls = srcSets.map(srcSet => srcSet.split(' ')[0]);
-  srcSetUrls.forEach(srcSetUrl => {
-    matcher(srcSetUrl, new URI(srcSetUrl));
-  });
-}

--- a/tests/unit/components/imgix-image-test.js
+++ b/tests/unit/components/imgix-image-test.js
@@ -15,7 +15,7 @@ test('it does not throw an exception when given an undefined path', function(ass
   assert.equal(component._state, 'inDOM');
 });
 
-test('the generated img has a srcSet in the format of 2x, 3x when passing a fixed width', function(assert) {
+test('the generated img has a srcSet in the format of 2x, 3x, 4x, 5x when passing a fixed width', function(assert) {
   const component = this.subject();
   setProperties(component, {
     path: '/users/1.png',
@@ -24,13 +24,13 @@ test('the generated img has a srcSet in the format of 2x, 3x when passing a fixe
 
   const srcSet = component.get('srcSet');
   const actualNumberOfSrcSets = srcSet.split(', ').length;
-  assert.equal(actualNumberOfSrcSets, 2);
+  assert.equal(actualNumberOfSrcSets, 4);
   srcSet.split(', ').forEach(srcSet => {
     assert.ok(srcSet.split(' ')[1].match(/^\dx$/));
   });
 });
 
-test('the generated img has a srcSet in the format of 2x, 3x when passing a fixed height', function(assert) {
+test('the generated img has a srcSet in the format of 2x, 3x, 4x, 5x when passing a fixed height', function(assert) {
   const component = this.subject();
   setProperties(component, {
     path: '/users/1.png',
@@ -39,7 +39,7 @@ test('the generated img has a srcSet in the format of 2x, 3x when passing a fixe
 
   const srcSet = component.get('srcSet');
   const actualNumberOfSrcSets = srcSet.split(', ').length;
-  assert.equal(actualNumberOfSrcSets, 2);
+  assert.equal(actualNumberOfSrcSets, 4);
   srcSet.split(', ').forEach(srcSet => {
     assert.ok(srcSet.split(' ')[1].match(/^\dx$/));
   });

--- a/tests/unit/components/imgix-image-test.js
+++ b/tests/unit/components/imgix-image-test.js
@@ -1,4 +1,4 @@
-import { get, setProperties } from '@ember/object';
+import { setProperties } from '@ember/object';
 import { moduleForComponent, test } from 'ember-qunit';
 import URI from 'jsuri';
 import config from 'ember-get-config';
@@ -36,20 +36,52 @@ test('it sets the source correctly', function(assert) {
     _dpr: 1
   });
 
-  component.didResize(400, 300);
-
   assert.ok(component.get('src'));
 
   const uri = new URI(component.get('src'));
+  const srcSet = component.get('srcSet');
 
   assert.equal(config.APP.imgix.source, uri.host());
   assert.equal('https', uri.protocol());
   assert.equal('/users/1.png', uri.path());
-  assert.equal(uri.getQueryParamValue('w'), 400);
-  assert.equal(uri.getQueryParamValue('h'), 300);
-  assert.ok(uri.getQueryParamValue('dpr'));
   assert.equal(uri.hasQueryParam('crop'), false);
   assert.equal(uri.getQueryParamValue('fit'), 'crop');
+  assert.ok(srcSet.indexOf('/users/1.png') > -1);
+});
+
+test('the generated img has the correct number of srcSets', function(assert) {
+  const expectedNumberOfSrcSets = 32;
+
+  const component = this.subject();
+  setProperties(component, {
+    path: '/users/1.png'
+  });
+
+  const srcSet = component.get('srcSet');
+  const actualNumberOfSrcSets = srcSet.split(',').length;
+  assert.equal(actualNumberOfSrcSets, expectedNumberOfSrcSets);
+});
+test('the generated img has srcSets in the correct format', function(assert) {
+  const component = this.subject();
+  setProperties(component, {
+    path: '/users/1.png'
+  });
+
+  const srcSet = component.get('srcSet');
+  const srcSets = srcSet.split(',').map(v => v.trim());
+
+  const srcSetsWithoutFallback = srcSets.slice(0, -1);
+
+  srcSetsWithoutFallback.forEach(srcSet => {
+    assert.equal(srcSet.split(' ').length, 2);
+    const [url, width] = srcSet.split(' ');
+    assert.ok(url);
+    assert.ok(width.match(/^\d+w$/));
+  });
+
+  const fallbackSrcSet = srcSets[srcSets.length - 1];
+  assert.equal(fallbackSrcSet.split(' ').length, 1);
+  assert.notOk(fallbackSrcSet.match(/^\d+w$/));
 });
 
 test('the generated src url has an ixlib parameter', function(assert) {
@@ -57,7 +89,6 @@ test('the generated src url has an ixlib parameter', function(assert) {
   setProperties(component, {
     path: '/users/1.png'
   });
-  component.didResize(400, 300);
 
   const src = component.get('src');
   const url = new URI(src);
@@ -71,7 +102,6 @@ test('setting disableLibraryParam should cause the url not to contain an ixlib p
     path: '/users/1.png',
     disableLibraryParam: true
   });
-  component.didResize(400, 300);
 
   const src = component.get('src');
   assert.ok(src.includes('ixlib=ember-') === false);
@@ -85,59 +115,9 @@ test('setting disableLibraryParam in the global config should cause the url not 
   setProperties(component, {
     path: '/users/1.png'
   });
-  component.didResize(400, 300);
 
   const src = component.get('src');
   assert.ok(src.includes('ixlib=ember-') === false);
 
   config.APP.imgix.disableLibraryParam = oldDisableLibraryParam;
-});
-
-test('it does not generate a source without a width', function(assert) {
-  const component = this.subject();
-
-  setProperties(component, {
-    path: '/users/1.png',
-    _width: null
-  });
-
-  assert.equal(null, get(component, 'src'));
-});
-
-test('it respects the pixel step', function(assert) {
-  const component = this.subject();
-
-  setProperties(component, {
-    path: '/users/1.png',
-    pixelStep: 10
-  });
-
-  component.didResize(405, 300);
-
-  const uri = new URI(component.get('src'));
-
-  assert.equal(
-    uri.getQueryParamValue('w'),
-    '410',
-    `Expected a step up to 410, instead stepped to: ${uri.getQueryParamValue(
-      'w'
-    )}`
-  );
-});
-
-test('the dpr is constrained to a precision of 3', function(assert) {
-  const oldDpr = window.devicePixelRatio;
-  window.devicePixelRatio = 1.33333;
-
-  const component = this.subject();
-
-  setProperties(component, {
-    path: 'test.png'
-  });
-  component.didResize(100, 100);
-  const uri = new URI(component.get('src'));
-
-  assert.equal(uri.getQueryParamValue('dpr'), '1.33');
-
-  window.devicePixelRatio = oldDpr;
 });


### PR DESCRIPTION
## Description

This PR fundamentally changes the approach taken to responsiveness. Previously, the image (or component) was rendered with an empty image, and the size of the resulting DOM element was measured. An image was loaded with these dimensions, ensuring that the image loaded was only as large as needed. Now, this component achieves the same behaviour by leveraging new native browser features, srcSet and sizes. This allows the browser to load an appropriate size based on the expected image size, which is calculated based on sizes. This has an added benefit that images can load much quicker as the browser can load them as soon as page layout has completed, or sooner (e.g. if sizes is 100vw). This will work well with Fastboot.

The significant amount of breaking changes makes sense due to a lot of the props no longer making sense.

## TODO

- [x] README
- [ ] ~Update dummy app examples - after offline discuss about aspect ratio~
- [ ] ~maintaining aspect ratio with dpr~
- [x] add disableSrcSet attribute
- [x] remove didUpdateAttrs
- [x] remove "sizes is required"

### New Feature

- [x] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Review the changes to the tests. The examples can also be served by cloning this PR, running `npm install` and then `ember serve`

BREAKING CHANGES:

- srcSet behaviour has changed to use sizes + srcSets
- the following attributes have been removed: pixelStep, auto