### PR TITLE
feat: add component which renders an image to fit its constrained size

### DIFF
--- a/addon/components/imgix-image-fluid.js
+++ b/addon/components/imgix-image-fluid.js
@@ -1,0 +1,149 @@
+import Component from '@ember/component';
+import { computed, get, set } from '@ember/object';
+import { tryInvoke } from '@ember/utils';
+import config from 'ember-get-config';
+import EmberError from '@ember/error';
+import ImgixClient from 'imgix-core-js';
+import URI from 'jsuri';
+import { debounce } from '@ember/runloop';
+import { constants, targetWidths, toFixed } from '../common';
+import layout from '../templates/components/imgix-image-fluid';
+import ResizeAware from 'ember-resize-aware/mixins/resize-aware';
+
+export default Component.extend(ResizeAware, {
+  layout,
+  tagName: '',
+
+  path: null, // The path to your image
+  aspectRatio: null,
+  crop: null,
+  fit: 'crop',
+  pixelStep: 10,
+  onLoad: null,
+  onError: null,
+  crossorigin: 'anonymous', // img element crossorigin attr
+  alt: '', // img element alt attr
+  draggable: true, // img element draggable attr
+  options: {}, // arbitrary imgix options
+  disableLibraryParam: false,
+
+  width: null,
+  height: null,
+  sizes: null,
+  disableSrcSet: false,
+
+  debounceRate: 400,
+
+  _width: null,
+  _height: null,
+
+  actions: {
+    handleChildInsert(childElement) {
+      set(this, 'childElement', childElement);
+
+      this.didResize(
+        get(this, 'width') ||
+          get(this, '_width') ||
+          childElement.getBoundingClientRect().width ||
+          childElement.parentElement.getBoundingClientRect().width,
+        get(this, 'height') ||
+          get(this, '_height') ||
+          childElement.getBoundingClientRect().height ||
+          childElement.parentElement.getBoundingClientRect().height
+      );
+    }
+  },
+
+  didResize(width, height) {
+    console.log('Resizing with w, h:', width, ',', height);
+    if (get(this, 'path')) {
+      const newDpr = toFixed(2, window.devicePixelRatio || 1);
+      const newWidth =
+        Math.ceil(
+          (get(this, '_pathAsUri').getQueryParamValue('w') || width) /
+            get(this, 'pixelStep')
+        ) *
+        get(this, 'pixelStep') *
+        newDpr;
+      const newHeight =
+        Math.floor(
+          get(this, 'aspectRatio')
+            ? newWidth / get(this, 'aspectRatio')
+            : get(this, '_pathAsUri').getQueryParamValue('h') || height
+        ) * newDpr;
+
+      console.log('Setting w x h: ', newWidth, 'x', newHeight);
+      set(this, '_width', newWidth);
+      set(this, '_height', newHeight);
+    }
+  },
+
+  didInsertElement(...args) {
+    this._super(...args);
+
+    // TODO: Update these to work with HOC
+    if (get(this, 'onLoad')) {
+      // this._handleImageLoad = this._handleImageLoad.bind(this);
+      // this.element.addEventListener('load', this._handleImageLoad);
+    }
+
+    if (get(this, 'onError')) {
+      // this._handleImageError = this._handleImageError.bind(this);
+      // this.element.addEventListener('error', this._handleImageError);
+    }
+  },
+
+  didUpdateAttrs(...args) {
+    this._super(...args);
+
+    if (typeof FastBoot === 'undefined') {
+      const childElement = get(this, 'childElement');
+      this.didResize(
+        get(this, 'width') ||
+          get(this, '_width') ||
+          childElement.getBoundingClientRect().width ||
+          childElement.parentElement.getBoundingClientRect().width,
+        get(this, 'height') ||
+          get(this, '_height') ||
+          childElement.getBoundingClientRect().height ||
+          childElement.parentElement.getBoundingClientRect().height
+      );
+    }
+  },
+
+  willDestroyElement(...args) {
+    if (get(this, 'onLoad') && typeof FastBoot === 'undefined') {
+      this.element.removeEventListener('load', this._handleImageLoad);
+    }
+
+    if (get(this, 'onError') && typeof FastBoot === 'undefined') {
+      this.element.removeEventListener('error', this._handleImageError);
+    }
+
+    this._super(...args);
+  },
+
+  _pathAsUri: computed('path', function() {
+    if (!get(this, 'path')) {
+      return false;
+    }
+
+    return new URI(get(this, 'path'));
+  }),
+
+  _handleImageLoad(event) {
+    debounce(
+      this,
+      () => !get(this, 'isDestroyed') && tryInvoke(this, 'onLoad', [event]),
+      500
+    );
+  },
+
+  _handleImageError(event) {
+    debounce(
+      this,
+      () => !get(this, 'isDestroyed') && tryInvoke(this, 'onError', [event]),
+      500
+    );
+  }
+});

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -26,6 +26,7 @@ export default Component.extend({
   fit: 'crop',
   onLoad: null,
   onError: null,
+  onInsert: null,
   crossorigin: 'anonymous', // img element crossorigin attr
   alt: '', // img element alt attr
   draggable: true, // img element draggable attr
@@ -41,6 +42,10 @@ export default Component.extend({
 
   didInsertElement(...args) {
     this._super(...args);
+
+    if (get(this, 'onInsert')) {
+      tryInvoke(this, 'onInsert', [this.element]);
+    }
 
     if (get(this, 'onLoad')) {
       this._handleImageLoad = this._handleImageLoad.bind(this);

--- a/addon/templates/components/imgix-image-fluid.hbs
+++ b/addon/templates/components/imgix-image-fluid.hbs
@@ -1,0 +1,23 @@
+{{!-- Hi {{_width}} x {{_height}} --}}
+{{imgix-image
+path=path
+aspectRatio=aspectRatio
+crop=crop
+fit=fit
+onLoad=onLoad
+onError=onError
+crossorigin=crossorigin
+alt=alt
+draggable=draggable
+options=options
+disableLibraryParam=disableLibraryParam
+
+width=_width
+height=_height
+sizes=sizes
+disableSrcSet=disableSrcSet
+
+debounceRate=debounceRate
+
+onInsert=(action 'handleChildInsert')
+}}

--- a/app/components/imgix-image-fluid.js
+++ b/app/components/imgix-image-fluid.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-imgix/components/imgix-image-fluid';


### PR DESCRIPTION
## Description

This PR adds in a wrapper component `imgix-image-fluid` which brings back the old behaviour of this library. The old behaviour is to measure what size the parent would like the image to be, and to render that size exactly.

This is just exploratory work to see if this was possible. I'd be happy to hand it over to you @Duder-onomy if you'd like to pick this up and finish it off.

Some implementation details follow. The component wraps `imgix-image` and simply measures the width and height that it should be rendered at, and passes this down to imgix-image. Since `this.element` no longer works when wrapping an element (without using an enclosing `div`), `onInsert` has been added to `imgix-image`, which will provide `this.element` from `imgix-image` to `imgix-image-fluid` to measure. Currently `ember-resize-aware` doesn't use this (and why would it), so something will need to be changed here for resizing to work.

## TODO

- [ ] Fix resize behaviour
- [ ] Tests

### New Feature

- [x] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [ ] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [ ] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

No tests yet. 