### PR TITLE
 chore: update imgix-image-wrapped deprecations to be deprecated in v3

### DIFF
--- a/addon/components/imgix-image-wrapped.js
+++ b/addon/components/imgix-image-wrapped.js
@@ -10,11 +10,11 @@ export default Component.extend(ResizeAware, ImgixPathBehavior, {
   init() {
     this._super(...arguments);
     deprecate(
-      'imgix-image-wrapped is deprecated and will be removed in ember-cli-imgix@2. Please migrate to using imgix-image instead.',
+      'imgix-image-wrapped is deprecated and will be removed in ember-cli-imgix@3. Please migrate to using imgix-image instead.',
       false,
       {
         id: 'ember-cli-imgix/imgix-image-wrapper-deprecation',
-        until: '2.0.0'
+        until: '3.0.0'
       }
     );
   }


### PR DESCRIPTION
## Description

This PR updates the `imgix-image-wrapped` deprecation warning to say it will be removed in v3, rather than v2, as we are about to release v2 earlier than we thought we would be.


