### PR TITLE
fix: update debug params to work with srcset

### DIFF
--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -246,7 +246,7 @@ export default Component.extend({
               ...options,
               ...debugParams,
               w: targetWidth,
-              h: targetHeight
+              ...(targetHeight ? { h: targetHeight } : {})
             };
             const url = buildWithOptions(urlOptions);
             return `${url} ${targetWidth}w`;


### PR DESCRIPTION
## Description

This PR updates the debug helper (shows the resolution of images) to work with the recent srcset update.

## Steps to Test

Review changes to implementation. 

Or, if the reviewer would like to check this locally.

1. Clone this PR, `npm install`, etc.
2. Run the examples with `npm run start`. Open the examples in a browser (url will be shown in terminal)
3. Observe that debug information is shown for images.
4. Change debug to `false` in `tests/dummy/config/environment.js`
5. Wait for page to refresh and observe that debug information is hidden.