### PR TITLE
fix: generate height when width + ar is given, or vice versa

### DIFF
--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -158,10 +158,16 @@ export default Component.extend({
           }
         );
       }
-
-      // Setup
       const widthProp = get(this, 'width');
       const heightProp = get(this, 'height');
+      if (isDimensionInvalid(widthProp) || isDimensionInvalid(heightProp)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[imgix] Either the width or height passed to this component (w: ${widthProp}, h: ${heightProp}) was invalid. Both width and height need to be a number greater than 0, or undefined.`
+        );
+      }
+
+      // Setup
       const pathAsUri = get(this, '_pathAsUri');
       const disableSrcSet = get(this, 'disableSrcSet');
       const client = get(this, '_client');
@@ -348,3 +354,7 @@ export default Component.extend({
     );
   }
 });
+
+function isDimensionInvalid(widthProp) {
+  return widthProp != null && (typeof widthProp !== 'number' || widthProp <= 0);
+}

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -200,21 +200,24 @@ export default Component.extend({
         if (widthProp && heightProp && aspectRatio) {
           // eslint-disable-next-line no-console
           console.warn(
-            `[imgix] All three of width, height, and aspect ratio were passed. The aspect ratio prop has not effect in this configuration.`
+            `[imgix] All three of width, height, and aspect ratio were passed. The aspect ratio prop has no effect in this configuration.`
           );
         }
         if (!widthProp && !heightProp && disableSrcSet && aspectRatio) {
           // eslint-disable-next-line no-console
           console.warn(
-            `[imgix] The aspect ratio prop has not effect when both width and height are not set, and when srcsets are disabled. To use aspect ratio, please either pass width or height values, or enable src sets.`
+            `[imgix] The aspect ratio prop has no effect when when srcsets are disabled and neither width nor height are set. To use aspect ratio, please either pass a width or height value, or enable src sets.`
           );
         }
 
-        if (
-          !(widthProp || heightProp) ||
-          (widthProp && heightProp) ||
-          !aspectRatioDecimal
-        ) {
+        const neitherWidthNorHeightPassed = !(widthProp || heightProp);
+        const bothWidthAndHeightPassed = widthProp && heightProp;
+        const shouldReturnOriginalDimensions =
+          neitherWidthNorHeightPassed || // we need at least one dimension to generate the other one
+          bothWidthAndHeightPassed || // if both dimensions are already passed, we don't need to generate one
+          !aspectRatioDecimal; // can't generate dimensions without an AR
+
+        if (shouldReturnOriginalDimensions) {
           return { width: widthProp, height: heightProp };
         }
 

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -197,9 +197,6 @@ export default Component.extend({
 
       // Ensure width and height are set correctly according to aspect ratio
       const { width, height } = (() => {
-        if (!aspectRatioDecimal) {
-          return { widthProp, heightProp };
-        }
         if (widthProp && heightProp && aspectRatio) {
           // eslint-disable-next-line no-console
           console.warn(
@@ -211,6 +208,14 @@ export default Component.extend({
           console.warn(
             `[imgix] The aspect ratio prop has not effect when both width and height are not set, and when srcsets are disabled. To use aspect ratio, please either pass width or height values, or enable src sets.`
           );
+        }
+
+        if (
+          !(widthProp || heightProp) ||
+          (widthProp && heightProp) ||
+          !aspectRatioDecimal
+        ) {
+          return { width: widthProp, height: heightProp };
         }
 
         if (widthProp) {

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -170,6 +170,27 @@ module('Integration | Component | imgix image', function(hooks) {
         assert.notOk(uri.getQueryParamValue('ar'));
       });
     });
+
+    module('fixed dimensions', function() {
+      test(`it generates the correct image height when a width and ar are passed`, async function(assert) {
+        await render(
+          hbs`<div>{{imgix-image path="/users/1.png" options=(hash ar="2:1") width=200 }}</div>`
+        );
+
+        expectSrcsTo(this.$, (_, urlURI) => {
+          assert.equal(urlURI.getQueryParamValue('h'), 100);
+        });
+      });
+      test(`it generates the correct image width when a height and ar are passed`, async function(assert) {
+        await render(
+          hbs`<div>{{imgix-image path="/users/1.png" options=(hash ar="2:1") height=200 }}</div>`
+        );
+
+        expectSrcsTo(this.$, (_, urlURI) => {
+          assert.equal(urlURI.getQueryParamValue('w'), 400);
+        });
+      });
+    });
   });
 
   test(`it respects the width and height passed in`, async function(assert) {
@@ -240,6 +261,7 @@ module('Integration | Component | imgix image', function(hooks) {
   });
 
   // matcher should be in the form (url: string, uri: URI) => boolean
+  // Should work for both w-type srcsets and dpr srcsets
   function expectSrcsTo($, matcher) {
     const src = $('img').attr('src');
     matcher(src, new URI(src));


### PR DESCRIPTION
## Description

Previously, the aspect ratio implementation did not generate the height when a width + aspect ratio was passed. This broke the backwards compatibility of this feature. 

This PR fixes that, and will generate either the height when width + ar is passed, or width when height + ar is passed. 

**Note for reviewers:** This PR also incorporates a refactor of the srcset generation logic to make it easier to understand, given the new requirements.

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Review new tests.
