### PR TITLE
feat: add container to render image as background behind children

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,25 @@ module.exports = function(environment) {
 ```hbs
 {{imgix-image path="/test.png" disableLibraryParam={true} }}
 ```
+### imgix-bg
+
+This component will render a `div` whose `background-image` is set to the given image path. Content can be added within the `imgix-bg` tags and the component will automatically resize to fit around it.
+
+```hbs
+{{#imgix-bg path='/users/1.png' }}
+  Some content here
+{{/imgix-bg}}
+```
+
+This will generate html similar to the following:
+
+```html
+<div style="background-image: url('https://my-social-network.com/users/1.png?fit=crop&w=1246&h=15&dpr=2&ixlib=ember-2.0.0');background-size: cover" class="imgix-bg">    
+  Some content here
+</div>
+```
+
+**Note:** `imgix-bg` will respect any global default parameters unless explicitly overriden.
 
 ### imgix-image-wrapped - DEPRECATED
 

--- a/addon/common/findClosest.js
+++ b/addon/common/findClosest.js
@@ -1,0 +1,27 @@
+/**
+ * Finds the closest value in the search array to the value provided using a binary search
+ * If the value is in the middle of two candidate values, it chooses the higher value
+ */
+export default function findClosest(searchValue, arr) {
+  if (searchValue < arr[0]) {
+    return arr[0];
+  }
+  if (searchValue > arr[arr.length - 1]) {
+    return arr[arr.length - 1];
+  }
+  var mid;
+  var lo = 0;
+  var hi = arr.length - 1;
+  while (hi - lo > 1) {
+    mid = Math.floor((lo + hi) / 2);
+    if (arr[mid] < searchValue) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  if (searchValue - arr[lo] < arr[hi] - searchValue) {
+    return arr[lo];
+  }
+  return arr[hi];
+}

--- a/addon/common/index.js
+++ b/addon/common/index.js
@@ -1,5 +1,6 @@
 export * from './lib';
 export { default as targetWidths } from './targetWidths';
 import constants from './constants';
+export { default as findClosest } from './findClosest';
 
 export { constants };

--- a/addon/common/lib.js
+++ b/addon/common/lib.js
@@ -1,1 +1,1 @@
-export const toFixed = (dp, value) => +value.toFixed(2);
+export const toFixed = (dp, value) => +value.toFixed(dp);

--- a/addon/components/imgix-bg.js
+++ b/addon/components/imgix-bg.js
@@ -30,7 +30,7 @@ function isDimensionInvalid(widthProp) {
 
 export default Component.extend(ResizeAware, {
   tagName: 'div',
-  classNames: get(config, 'APP.imgix.classNames') || 'imgix-bg',
+  classNameBindings: ['elementClassNames'],
   attributeBindings: ['style', 'alt'],
 
   path: null, // The path to your image
@@ -92,7 +92,6 @@ export default Component.extend(ResizeAware, {
     'fit',
     'disableSrcSet',
     function() {
-      console.log('compute src');
       // Warnings, checks
       if (!get(this, 'path')) {
         return;
@@ -163,6 +162,8 @@ export default Component.extend(ResizeAware, {
 
       // Build base options
       const options = {
+        // default params from application config
+        ...(config.APP.imgix.defaultParams || {}),
         // Add fit from 'fit' prop
         fit: get(this, 'fit'),
         // Add width from computed width, or width prop
@@ -189,6 +190,10 @@ export default Component.extend(ResizeAware, {
       return src;
     }
   ),
+
+  elementClassNames: computed('config.APP.imgix.classNames', function() {
+    return config.APP.imgix.classNames || 'imgix-bg';
+  }),
 
   didResize(width, height) {
     if (get(this, 'path')) {

--- a/addon/components/imgix-bg.js
+++ b/addon/components/imgix-bg.js
@@ -1,0 +1,229 @@
+import Component from '@ember/component';
+import { computed, set, get } from '@ember/object';
+import { htmlSafe } from '@ember/string';
+import config from 'ember-get-config';
+import ResizeAware from 'ember-resize-aware/mixins/resize-aware';
+import { toFixed, constants, targetWidths, findClosest } from '../common';
+import URI from 'jsuri';
+import EmberError from '@ember/error';
+import ImgixClient from 'imgix-core-js';
+
+const buildDebugParams = ({ width, height }) => {
+  return {
+    txt64: `${width != null ? width : 'auto'} x ${
+      height != null ? height : 'auto'
+    }`,
+    txtalign: 'center,bottom',
+    txtsize: 40,
+    txtfont: 'Helvetica Neue',
+    txtclr: 'ffffff',
+    txtpad: 40,
+    txtfit: 'max'
+  };
+};
+
+const findNearestWidth = actualWidth => findClosest(actualWidth, targetWidths);
+
+function isDimensionInvalid(widthProp) {
+  return widthProp != null && (typeof widthProp !== 'number' || widthProp <= 0);
+}
+
+export default Component.extend(ResizeAware, {
+  tagName: 'div',
+  classNames: get(config, 'APP.imgix.classNames') || 'imgix-bg',
+  attributeBindings: ['style', 'alt'],
+
+  path: null, // The path to your image
+  crop: null,
+  fit: 'crop',
+  alt: '', // img element alt attr
+  options: {}, // arbitrary imgix options
+  disableLibraryParam: false,
+
+  width: null,
+  height: null,
+  sizes: null,
+  disableSrcSet: false,
+
+  style: computed('_src', function() {
+    const src = get(this, '_src');
+
+    const style = {
+      ...(src && {
+        'background-image': `url('${src}')`,
+        'background-size': 'cover'
+      })
+    };
+    return htmlSafe(
+      Object.keys(style)
+        .map(key => `${key}: ${style[key]}`)
+        .join(';')
+    );
+  }),
+
+  _client: computed('disableLibraryParam', function() {
+    if (!config || !get(config, 'APP.imgix.source')) {
+      throw new EmberError(
+        'Could not find a source in the application configuration. Please configure APP.imgix.source in config/environment.js. See https://github.com/imgix/ember-cli-imgix for more information.'
+      );
+    }
+
+    const disableLibraryParam =
+      get(config, 'APP.imgix.disableLibraryParam') ||
+      get(this, 'disableLibraryParam');
+
+    return new ImgixClient({
+      host: config.APP.imgix.source,
+      includeLibraryParam: false, // to disable imgix-core-js setting ixlib=js by default
+      libraryParam: disableLibraryParam
+        ? undefined
+        : `ember-${constants.APP_VERSION}`
+    });
+  }),
+
+  _src: computed(
+    '_width',
+    '_height',
+    'path',
+    '_pathAsUri',
+    'width',
+    'height',
+    'crop',
+    'fit',
+    'disableSrcSet',
+    function() {
+      console.log('compute src');
+      // Warnings, checks
+      if (!get(this, 'path')) {
+        return;
+      }
+      const forcedWidth = get(this, 'width');
+      const forcedHeight = get(this, 'height');
+      const measuredWidth = get(this, '_width');
+      const measuredHeight = get(this, '_height');
+
+      const hasDOMDimensions = measuredWidth != null;
+      if (isDimensionInvalid(forcedWidth) || isDimensionInvalid(forcedHeight)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[imgix] Either the width or height passed to this component (w: ${forcedWidth}, h: ${forcedHeight}) was invalid. Both width and height need to be a number greater than 0, or undefined.`
+        );
+      }
+
+      // Setup
+      const pathAsUri = get(this, '_pathAsUri');
+      const client = get(this, '_client');
+      const buildWithOptions = options =>
+        client.buildURL(pathAsUri.path(), options);
+
+      const shouldShowDebugParams = get(config, 'APP.imgix.debug');
+
+      const imgixOptions = get(this, 'options') || {};
+      const { width, height } = (() => {
+        const bothWidthAndHeightPassed =
+          forcedWidth != null && forcedHeight != null;
+
+        if (bothWidthAndHeightPassed) {
+          return { width: forcedWidth, height: forcedHeight };
+        }
+
+        if (!hasDOMDimensions) {
+          return { width: undefined, height: undefined };
+        }
+        const ar = measuredWidth / measuredHeight;
+
+        const neitherWidthNorHeightPassed =
+          forcedWidth == null && forcedHeight == null;
+        if (neitherWidthNorHeightPassed) {
+          const width = findNearestWidth(measuredWidth);
+          const height = Math.ceil(width / ar);
+          return { width, height };
+        }
+        if (forcedWidth != null) {
+          const height = Math.ceil(forcedWidth / ar);
+          return { width: forcedWidth, height };
+        } else if (forcedHeight != null) {
+          const width = Math.ceil(forcedHeight * ar);
+          return { width, height: forcedHeight };
+        }
+      })();
+
+      if (width == null || height == null) {
+        return undefined;
+      }
+
+      const debugParams = shouldShowDebugParams
+        ? buildDebugParams({ width, height })
+        : {};
+
+      const dpr = toFixed(
+        2,
+        Number.parseFloat(imgixOptions.dpr) || get(this, '_dpr') || 1
+      );
+
+      // Build base options
+      const options = {
+        // Add fit from 'fit' prop
+        fit: get(this, 'fit'),
+        // Add width from computed width, or width prop
+        ...(width != null ? { w: width } : {}),
+        // Add height from computed height, or height prop
+        ...(height != null ? { h: height } : {}),
+        // Add crop from 'crop' prop
+        ...(get(this, 'crop') != null ? { crop: get(this, 'crop') } : {}),
+        // Add imgix options from 'options' prop
+        ...imgixOptions,
+        // Add debug params
+        ...debugParams,
+        // Add any parameters that were set in the 'path' prop
+        ...pathAsUri.queryPairs.reduce((memo, param) => {
+          memo[param[0]] = param[1];
+          return memo;
+        }, {}),
+        dpr
+      };
+
+      // Build src from base options
+      const src = buildWithOptions(options);
+
+      return src;
+    }
+  ),
+
+  didResize(width, height) {
+    if (get(this, 'path')) {
+      const newWidth = Math.ceil(
+        get(this, '_pathAsUri').getQueryParamValue('w') || width
+      );
+      const newHeight = Math.floor(
+        get(this, '_pathAsUri').getQueryParamValue('h') || height
+      );
+      const newDpr = toFixed(2, window.devicePixelRatio || 1);
+
+      set(this, '_width', newWidth);
+      set(this, '_height', newHeight);
+      set(this, '_dpr', newDpr);
+    }
+  },
+
+  _pathAsUri: computed('path', function() {
+    if (!get(this, 'path')) {
+      return false;
+    }
+
+    return new URI(get(this, 'path'));
+  }),
+
+  didInsertElement(...args) {
+    this._super(...args);
+
+    this.didResize(
+      get(this, '_width') ||
+        this.element.clientWidth ||
+        this.element.parentElement.clientWidth,
+      get(this, '_height') ||
+        this.element.clientHeight ||
+        this.element.parentElement.clientHeight
+    );
+  }
+});

--- a/app/components/imgix-bg.js
+++ b/app/components/imgix-bg.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-imgix/components/imgix-bg';

--- a/tests/integration/components/imgix-background-test.js
+++ b/tests/integration/components/imgix-background-test.js
@@ -6,9 +6,11 @@ import ImgixBG from 'ember-cli-imgix/components/imgix-bg';
 
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
+import { assign } from '@ember/polyfills';
+import config from 'ember-get-config';
 import hbs from 'htmlbars-inline-precompile';
 import URI from 'jsuri';
-// import config from 'ember-get-config';
+
 const isIE = (() => {
   const ua = window.navigator.userAgent;
   const isIE = /MSIE|Trident/.test(ua);
@@ -260,19 +262,20 @@ module('Integration | Component | imgix background', function(hooks) {
     const oldDPR = global.devicePixelRatio;
     global.devicePixelRatio = 2;
 
-    await render(hbs`
-        <div>
-          <style>.imgix-bg { width: 10px; height: 10px; }</style>
-          {{#imgix-bg
-            path="/users/1.png"
-            options=(hash
-              dpr=3
-            )
-          }}
-            Content
-          {{/imgix-bg}}
-        </div>
-          `);
+    await render(
+      hbs`
+      <div>
+        <style>.imgix-bg { width: 10px; height: 10px; }</style>
+        {{#imgix-bg
+          path="/users/1.png"
+          options=(hash
+            dpr=3
+          )
+        }}
+          Content
+        {{/imgix-bg}}
+      </div>
+      `);
 
     const bgImageSrcURL = findURI();
 
@@ -310,4 +313,219 @@ module('Integration | Component | imgix background', function(hooks) {
 
     assert.equal(find('.imgix-bg').getAttribute('alt'), 'Test alt');
   });
+
+  module('application config', function(hooks) {
+    hooks.beforeEach(function() {
+      this.initialAppConfig = assign({}, config.APP.imgix);
+    });
+
+    hooks.afterEach(function() {
+      config.APP.imgix = this.initialAppConfig;
+    });
+
+    module('debug params', function() {
+      test('it does not render debug params when passing debug false', async function(assert) {
+        config.APP.imgix.debug = false;
+
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png"
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+          `);
+
+        const debugParams = [
+          'txtalign',
+          'txtclr',
+          'txtfit',
+          'txtfont',
+          'txtpad',
+          'txtsize',
+        ];
+
+        expectSrcsTo(this.$, (_, uri) => debugParams.forEach(debugParam => assert.notOk(uri.hasQueryParam(debugParam))));
+      });
+
+      test('it will render debug params when passing debug true', async function(assert) {
+        config.APP.imgix.debug = true;
+
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png"
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+          `);
+
+        const debugParams = [
+          'txtalign',
+          'txtclr',
+          'txtfit',
+          'txtfont',
+          'txtpad',
+          'txtsize',
+        ];
+
+        expectSrcsTo(this.$, (_, uri) => debugParams.forEach(debugParam => assert.ok(uri.hasQueryParam(debugParam))));
+      });
+    });
+
+    module('default css class', function() {
+      test('it allows overriding the default class via config', async function(assert) {
+        assert.expect(1);
+
+        config.APP.imgix.classNames = 'imgix-is-rad';
+
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png"
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+          `);
+
+        assert.ok(this.$('div').hasClass('imgix-is-rad'));
+      });
+
+      test('the default class given to the rendered element is `imgix-bg`', async function(assert) {
+        assert.expect(1);
+
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png"
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+          `);
+
+        assert.ok(this.$('div').hasClass('imgix-bg'));
+      });
+    });
+
+    module('library param', function() {
+      test('it adds the library param to all srcs by default', async function(assert) {
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png"
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+          `);
+
+        expectSrcsTo(this.$, (_, uri) => assert.ok(uri.hasQueryParam('ixlib')));
+      });
+
+      test('it allows disabling the imigx library param via conifg', async function(assert) {
+        config.APP.imgix.disableLibraryParam = true;
+
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png"
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+          `);
+
+        expectSrcsTo(this.$, (_, uri) => assert.notOk(uri.hasQueryParam('ixlib')));
+      });
+    });
+
+    module('default params from app config', function() {
+      test('are respected ', async function(assert) {
+        config.APP.imgix.defaultParams = {
+          'toBoop': 'the-snoot',
+        };
+
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png"
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+          `);
+
+        expectSrcsTo(this.$, (_, uri) => assert.equal(uri.getQueryParamValue('toBoop'), 'the-snoot'));
+      });
+
+      test('`options` attr takes precedence', async function(assert) {
+        config.APP.imgix.defaultParams = {
+          auto: 'faces',
+        };
+
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png"
+              options=(hash
+                auto='format'
+              )
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+          `);
+
+        expectSrcsTo(this.$, (_, uri) => assert.equal(uri.getQueryParamValue('auto'), 'format'));
+      });
+
+      test('params on the path take precedence', async function(assert) {
+        config.APP.imgix.defaultParams = {
+          auto: 'faces',
+        };
+
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png?auto=format"
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+          `);
+
+        expectSrcsTo(this.$, (_, uri) => assert.equal(uri.getQueryParamValue('auto'), 'format'));
+      });
+    });
+  });
 });
+
+// matcher should be in the form (url: string, uri: URI) => boolean
+// Should work for both w-type srcsets and dpr srcsets
+function expectSrcsTo($, matcher) {
+  const div = $('div').find('.imgix-bg').attr('style');
+  const src = div.split("'")[1];
+  matcher(src, new URI(src));
+}

--- a/tests/integration/components/imgix-background-test.js
+++ b/tests/integration/components/imgix-background-test.js
@@ -1,0 +1,348 @@
+/* global Ember Promise global */
+import { module, test, skip } from 'qunit';
+
+import targetWidths from 'ember-cli-imgix/common/targetWidths';
+import ImgixBG from 'ember-cli-imgix/components/imgix-bg';
+
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import URI from 'jsuri';
+// import config from 'ember-get-config';
+const isIE = (() => {
+  const ua = window.navigator.userAgent;
+  const isIE = /MSIE|Trident/.test(ua);
+  return isIE;
+})();
+
+const findURI = () => {
+  const container = find('.imgix-bg');
+
+  if (!container) {
+    throw new Error('Cannot find container.');
+  }
+
+  const bgImageStyle = container.style;
+  console.log('bgImageStyle', bgImageStyle);
+
+  if (!bgImageStyle.backgroundImage) {
+    throw new Error(
+      "Cannot find style.background-image on background div. The element probably hasn't had time to measure the size of the DOM element."
+    );
+  }
+
+  const bgImageSrc = (() => {
+    const bgImage = bgImageStyle.backgroundImage;
+    // Mobile Safari trims speech marks from url('') styles, so this checks if they've been trimmed or not
+    if (bgImage.startsWith('url("') || bgImage.startsWith("url('")) {
+      return bgImageStyle.backgroundImage.slice(5, -2);
+    }
+    return bgImageStyle.backgroundImage.slice(4, -1);
+  })();
+
+  const bgImageSrcURI = new URI(bgImageSrc);
+  return bgImageSrcURI;
+};
+
+const shouldHaveDimensions = async (
+  assert,
+  { width: expectedWidth, height: expectedHeight },
+  markup
+) => {
+  await render(markup);
+
+  console.log(
+    "find('.imgix-bg').getBoundingClientRect()",
+    find('.imgix-bg').getBoundingClientRect()
+  );
+
+  const bgImageSrcURL = findURI();
+
+  assert.equal(bgImageSrcURL.getQueryParamValue('w'), '' + expectedWidth);
+  assert.equal(bgImageSrcURL.getQueryParamValue('h'), '' + expectedHeight);
+};
+
+const renderBGAndWaitUntilLoaded = async markup => {
+  return new Promise(async (resolve, reject) => {
+    let waitUntilHasStyle = (maxTimes = 20, delay = 10, n = 0) => {
+      // Find the element which has the class "bg-img"
+      const bgImageEl = find('.imgix-bg');
+      // Check if the element has loaded, which is shown by a truthy `background-image`
+      console.log('bgImageEl', bgImageEl.getAttribute('style'));
+      console.log(
+        'bgImageEl.style.backgroundImage',
+        bgImageEl.style.backgroundImage
+      );
+      if (bgImageEl.style.backgroundImage) {
+        return resolve(find('.imgix-bg'));
+      }
+
+      if (n >= maxTimes) {
+        return reject('Tries exceeded to wait for component to be ready');
+      }
+      setTimeout(() => waitUntilHasStyle(maxTimes, delay, n + 1), delay);
+    };
+
+    await render(markup);
+    setTimeout(waitUntilHasStyle, 10);
+  });
+};
+
+const renderAndCallbackBeforeImageLoad = async function(markup) {
+  let resolve, reject;
+
+  // Overriding didInsertElement to stop DOM measuring and subsequent rendering
+  this.owner.register(
+    'component:imgix-bg',
+    ImgixBG.extend({
+      didInsertElement() {
+        resolve();
+        this._super(...arguments);
+      }
+    })
+  );
+
+  render(markup);
+
+  return new Promise((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+};
+
+const shouldRenderNoBGImage = async function(assert, markup) {
+  await renderAndCallbackBeforeImageLoad.call(this, markup);
+
+  const container = find('.imgix-bg');
+  const bgImage = container.style.backgroundImage;
+
+  assert.ok(!bgImage.includes('url'));
+};
+
+const findClosestWidthFromTargetWidths = targetWidth =>
+  targetWidths.reduce((acc, value) => {
+    // <= ensures that the largest value is used
+    if (Math.abs(value - targetWidth) <= Math.abs(acc - targetWidth)) {
+      return value;
+    }
+    return acc;
+  }, Number.MAX_VALUE);
+
+module('Integration | Component | imgix background', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test(`renders a div`, async function(assert) {
+    await render(hbs`
+    {{#imgix-bg path="/users/1.png"}}Content{{/imgix-bg}}`);
+
+    assert.ok(this.$('div'));
+  });
+
+  module(`when neither width nor height are passed`, () => {
+    test(`renders nothing at first`, async function(assert) {
+      await shouldRenderNoBGImage.call(
+        this,
+        assert,
+        hbs`{{#imgix-bg path="/users/1.png"}}Content{{/imgix-bg}}`
+      );
+    });
+    test(`sets the size of the background image to the size of the containing element`, async function(assert) {
+      const targetWidth = 105;
+      const targetHeight = 110;
+      const aspectRatio = targetWidth / targetHeight;
+      await render(
+        Ember.HTMLBars.compile(`<div>
+          <style
+          >.imgix-bg { width: ${targetWidth}px; height: ${targetHeight}px}</style>
+          {{#imgix-bg path="/users/1.png"}}Content{{/imgix-bg}}
+        </div>`)
+      );
+
+      const bgImageSrcURL = findURI();
+
+      const expectedWidth = findClosestWidthFromTargetWidths(targetWidth);
+      const expectedHeight = Math.round(expectedWidth / aspectRatio);
+
+      assert.equal(bgImageSrcURL.getQueryParamValue('w'), `${expectedWidth}`);
+      assert.equal(bgImageSrcURL.getQueryParamValue('h'), `${expectedHeight}`);
+      assert.equal(bgImageSrcURL.getQueryParamValue('fit'), 'crop');
+    });
+  });
+  module('when both width and height provided', () => {
+    test('renders immediately when both width and height provided', async function(assert) {
+      await renderAndCallbackBeforeImageLoad.call(
+        this,
+        hbs`
+        {{#imgix-bg
+          path="/users/1.png"
+          width=300
+          height=350
+        }}
+          Content
+        {{/imgix-bg}}`
+      );
+
+      console.log('ASSERT');
+
+      const bgImageSrcURL = findURI();
+
+      assert.equal(bgImageSrcURL.getQueryParamValue('w'), '300');
+      assert.equal(bgImageSrcURL.getQueryParamValue('h'), '350');
+    });
+    test('sets width and height to values passed', async function(assert) {
+      const sut = await render(hbs`
+          <div>
+            <style>.imgix-bg { width: 200px; height: 250px; }</style>
+            {{#imgix-bg
+              path="/users/1.png"
+              width=300
+              height=350
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+          `);
+
+      const bgImageSrcURL = findURI();
+
+      assert.equal(bgImageSrcURL.getQueryParamValue('w'), '300');
+      assert.equal(bgImageSrcURL.getQueryParamValue('h'), '350');
+    });
+  });
+
+  module('when only width is passed', () => {
+    test('renders nothing at first', async function(assert) {
+      await shouldRenderNoBGImage.call(
+        this,
+        assert,
+        hbs`{{#imgix-bg path="/users/1.png" width=200}}Content{{/imgix-bg}}`
+      );
+    });
+    test('sets height dynamically', async function(assert) {
+      await shouldHaveDimensions(
+        assert,
+        { width: 200, height: 210 },
+        hbs`<div>
+          <style>.imgix-bg { width: 100px; height: 105px}</style>
+          {{#imgix-bg
+            path="/users/1.png"
+            width=200
+          }}
+            Content
+          {{/imgix-bg}}
+        </div>`
+      );
+    });
+  });
+  module('when only height is passed', () => {
+    test('renders nothing at first', async function(assert) {
+      await shouldRenderNoBGImage.call(
+        this,
+        assert,
+        hbs`{{#imgix-bg path="/users/1.png" height=200}}Content{{/imgix-bg}}`
+      );
+    });
+    test('sets width dynamically', async function(assert) {
+      await shouldHaveDimensions(
+        assert,
+        { width: 200, height: 210 },
+        hbs`<div>
+          <style>.imgix-bg { width: 100px; height: 105px}</style>
+          {{#imgix-bg
+            path="/users/1.png"
+            height=210
+          }}
+            Content
+          {{/imgix-bg}}
+        </div>`
+      );
+    });
+  });
+
+  test('scales the background image by the devices dpr', async function(assert) {
+    // window.devicePixelRatio is not allowed in IE.
+    if (isIE) {
+      return;
+    }
+    const oldDPR = global.devicePixelRatio;
+    global.devicePixelRatio = 2;
+
+    await render(
+      hbs`
+        <div>
+          <style>.imgix-bg { width: 10px; height: 10px; }</style>
+          {{#imgix-bg
+            path="/users/1.png"
+          }}
+            Content
+          {{/imgix-bg}}
+        </div>
+          `
+    );
+
+    const bgImageSrcURL = findURI();
+
+    assert.equal(bgImageSrcURL.getQueryParamValue('dpr'), '2');
+
+    global.devicePixelRatio = oldDPR;
+  });
+
+  test('the dpr can be overriden', async function(assert) {
+    // IE doesn't allow us to override window.devicePixelRatio
+    if (isIE) {
+      return;
+    }
+    const oldDPR = global.devicePixelRatio;
+    global.devicePixelRatio = 2;
+
+    await render(hbs`
+        <div>
+          <style>.imgix-bg { width: 10px; height: 10px; }</style>
+          {{#imgix-bg
+            path="/users/1.png"
+            options=(hash
+              dpr=3
+            )
+          }}
+            Content
+          {{/imgix-bg}}
+        </div>
+          `);
+
+    const bgImageSrcURL = findURI();
+
+    assert.equal(bgImageSrcURL.getQueryParamValue('dpr'), '3');
+
+    global.devicePixelRatio = oldDPR;
+  });
+
+  test(`the dpr is rounded to 2dp`, async function(assert) {
+    await render(hbs`
+        <div>
+          <style>.imgix-bg { width: 10px; height: 10px; }</style>
+          {{#imgix-bg
+            path="/users/1.png"
+            options=(hash
+              dpr=3.4444
+            )
+          }}
+            Content
+          {{/imgix-bg}}
+        </div>
+          `);
+
+    const bgImageSrcURL = findURI();
+
+    assert.equal(bgImageSrcURL.getQueryParamValue('dpr'), '3.44');
+  });
+
+  test(`can pass alt to component`, async function(assert) {
+    await render(hbs`
+    {{#imgix-bg path="1.png" alt="Test alt"}}
+    Content
+    {{/imgix-bg}}
+    `);
+
+    assert.equal(find('.imgix-bg').getAttribute('alt'), 'Test alt');
+  });
+});

--- a/tests/integration/components/imgix-background-test.js
+++ b/tests/integration/components/imgix-background-test.js
@@ -1,5 +1,5 @@
 /* global Ember Promise global */
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 
 import targetWidths from 'ember-cli-imgix/common/targetWidths';
 import ImgixBG from 'ember-cli-imgix/components/imgix-bg';
@@ -23,7 +23,6 @@ const findURI = () => {
   }
 
   const bgImageStyle = container.style;
-  console.log('bgImageStyle', bgImageStyle);
 
   if (!bgImageStyle.backgroundImage) {
     throw new Error(
@@ -51,45 +50,14 @@ const shouldHaveDimensions = async (
 ) => {
   await render(markup);
 
-  console.log(
-    "find('.imgix-bg').getBoundingClientRect()",
-    find('.imgix-bg').getBoundingClientRect()
-  );
-
   const bgImageSrcURL = findURI();
 
   assert.equal(bgImageSrcURL.getQueryParamValue('w'), '' + expectedWidth);
   assert.equal(bgImageSrcURL.getQueryParamValue('h'), '' + expectedHeight);
 };
 
-const renderBGAndWaitUntilLoaded = async markup => {
-  return new Promise(async (resolve, reject) => {
-    let waitUntilHasStyle = (maxTimes = 20, delay = 10, n = 0) => {
-      // Find the element which has the class "bg-img"
-      const bgImageEl = find('.imgix-bg');
-      // Check if the element has loaded, which is shown by a truthy `background-image`
-      console.log('bgImageEl', bgImageEl.getAttribute('style'));
-      console.log(
-        'bgImageEl.style.backgroundImage',
-        bgImageEl.style.backgroundImage
-      );
-      if (bgImageEl.style.backgroundImage) {
-        return resolve(find('.imgix-bg'));
-      }
-
-      if (n >= maxTimes) {
-        return reject('Tries exceeded to wait for component to be ready');
-      }
-      setTimeout(() => waitUntilHasStyle(maxTimes, delay, n + 1), delay);
-    };
-
-    await render(markup);
-    setTimeout(waitUntilHasStyle, 10);
-  });
-};
-
 const renderAndCallbackBeforeImageLoad = async function(markup) {
-  let resolve, reject;
+  let resolve;
 
   // Overriding didInsertElement to stop DOM measuring and subsequent rendering
   this.owner.register(
@@ -104,9 +72,8 @@ const renderAndCallbackBeforeImageLoad = async function(markup) {
 
   render(markup);
 
-  return new Promise((_resolve, _reject) => {
+  return new Promise(_resolve => {
     resolve = _resolve;
-    reject = _reject;
   });
 };
 
@@ -182,15 +149,13 @@ module('Integration | Component | imgix background', function(hooks) {
         {{/imgix-bg}}`
       );
 
-      console.log('ASSERT');
-
       const bgImageSrcURL = findURI();
 
       assert.equal(bgImageSrcURL.getQueryParamValue('w'), '300');
       assert.equal(bgImageSrcURL.getQueryParamValue('h'), '350');
     });
     test('sets width and height to values passed', async function(assert) {
-      const sut = await render(hbs`
+      await render(hbs`
           <div>
             <style>.imgix-bg { width: 200px; height: 250px; }</style>
             {{#imgix-bg


### PR DESCRIPTION
## Description

This PR adds a new component which enables an image to be rendered as a background behind children components.

This PR has existed for a while in react-imgix, and is being ported over to this library.

### New Feature

- [x] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Review new tests.