### PR TITLE
feat: add global default params

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ module.exports = function(environment) {
       imgix: {
         source: 'my-social-network.imgix.net',
         debug: true // Prints out diagnostic information on the image itself. Turn off in production.
+        debug: true, // Prints out diagnostic information on the image itself. Turn off in production.
+        classNames: 'imgix-image', // default class used on the img element
       }
     }
     // snip

--- a/README.md
+++ b/README.md
@@ -274,9 +274,9 @@ module.exports = function(environment) {
     APP: {
       imgix: {
         source: 'my-social-network.imgix.net',
-        debug: true // Prints out diagnostic information on the image itself. Turn off in production.
         debug: true, // Prints out diagnostic information on the image itself. Turn off in production.
         classNames: 'imgix-image', // default class used on the img element
+        defaultParams: {}, // optional params that will be used in all generated paths
       }
     }
     // snip

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -49,7 +49,7 @@ const buildDebugParams = ({ width, height }) => {
 
 export default Component.extend({
   tagName: 'img',
-  classNameBindings: ['elementClassName'],
+  classNameBindings: ['elementClassNames'],
   attributeBindings: [
     'alt',
     'crossorigin',

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -245,6 +245,8 @@ export default Component.extend({
 
       // Build base options
       const options = {
+        // default params from application config
+        ...(config.APP.imgix.defaultParams || {}),
         // Add fit from 'fit' prop
         fit: get(this, 'fit'),
         // Add width from computed width, or width prop

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -49,7 +49,7 @@ const buildDebugParams = ({ width, height }) => {
 
 export default Component.extend({
   tagName: 'img',
-  classNames: get(config, 'APP.imgix.classNames') || 'imgix-image',
+  classNameBindings: ['elementClassName'],
   attributeBindings: [
     'alt',
     'crossorigin',
@@ -337,6 +337,10 @@ export default Component.extend({
       }, {})
     });
     return placeholderURL;
+  }),
+
+  elementClassNames: computed('config.APP.imgix.classNames', function() {
+    return config.APP.imgix.classNames || 'imgix-image';
   }),
 
   _handleImageLoad(event) {

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -353,6 +353,44 @@ module('Integration | Component | imgix image', function(hooks) {
         expectSrcsTo(this.$, (_, uri) => assert.notOk(uri.hasQueryParam('ixlib')));
       });
     });
+
+    module('default params from app config', function() {
+      test('are respected ', async function(assert) {
+        config.APP.imgix.defaultParams = {
+          'toBoop': 'the-snoot',
+        };
+
+        await render(
+          hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png'}}</div>`
+        );
+
+        expectSrcsTo(this.$, (_, uri) => assert.equal(uri.getQueryParamValue('toBoop'), 'the-snoot'));
+      });
+
+      test('`options` attr takes precedence', async function(assert) {
+        config.APP.imgix.defaultParams = {
+          auto: 'faces',
+        };
+
+        await render(
+          hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png' options=(hash
+            auto='format'
+          )}}</div>`
+        );
+
+        expectSrcsTo(this.$, (_, uri) => assert.equal(uri.getQueryParamValue('auto'), 'format'));
+      });
+
+      test('params on the path take precedence', async function(assert) {
+        config.APP.imgix.defaultParams = {
+          auto: 'faces',
+        };
+
+        await render(
+          hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png?auto=format'}}</div>`
+        );
+
+        expectSrcsTo(this.$, (_, uri) => assert.equal(uri.getQueryParamValue('auto'), 'format'));
       });
     });
   });

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -3,12 +3,21 @@ import { module, test } from 'qunit';
 
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
+import { assign } from '@ember/polyfills';
 import hbs from 'htmlbars-inline-precompile';
 import URI from 'jsuri';
 import config from 'ember-get-config';
 
 module('Integration | Component | imgix image', function(hooks) {
   setupRenderingTest(hooks);
+
+  hooks.before(function() {
+    this.initialAppConfig = assign({}, config.APP.imgix);
+  });
+
+  hooks.afterEach(function() {
+    config.APP.imgix = this.initialAppConfig;
+  });
 
   test('it renders an image', async function(assert) {
     await render(hbs`{{imgix-image path="/users/1.png"}}`);
@@ -258,6 +267,31 @@ module('Integration | Component | imgix image', function(hooks) {
     );
 
     assert.equal(this.$('img').attr('crossorigin'), 'imgix-is-rad');
+  });
+
+
+  module('default css class', function() {
+    test('it allows setting overriding the default class via config', async function(assert) {
+      assert.expect(1);
+
+      config.APP.imgix.classNames = 'imgix-is-rad';
+
+      await render(
+        hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png' }}</div>`
+      );
+
+      assert.ok(this.$('img').hasClass('imgix-is-rad'));
+    });
+
+    test('the default class given to the rendered element is `imgix-image`', async function(assert) {
+      assert.expect(1);
+
+      await render(
+        hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png'}}</div>`
+      );
+
+      assert.ok(this.$('img').hasClass('imgix-image'));
+    });
   });
 
   // matcher should be in the form (url: string, uri: URI) => boolean


### PR DESCRIPTION
I wanted to be able to specify some default params from the applications config. Specifically, I wanted the `auto='format'` param. While implementing, I noticed the other global config options were untested so I added some tests for those while I was in there. 

## Description

* Adds tests for current global configuration options [`debug`, `classNames`, `disableLibraryParam`]
* Adds tests and feature for NEW global configuration option called `defaultParams` which is an object of default params that will be applied to all `src`'s.  
* Adds notes to the readme.

### New Feature

- [NA] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [✔️]  Run unit tests to ensure all existing tests are still passing
- [✔️] Add new passing unit tests to cover the code introduced by your PR
- [✔️] Update the readme
- [✔️] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [✔️] The PR title is in the [conventional commit](#conventional-commit-spec) format.

## Steps to Test

* Set a imgix param via the applications config, something like:
```
///
APP: {
    imgix: {
        path: ...,
        defaultParams: {
            auto: 'format',
        },
    },
},
///
```
* Observe that param being applied to all src's.
* Pass a param via the options hash or as params on the url.
* Observe that all other param setting methods take precedence over the global values.