### PR TITLE
fix: remove fallback src from srcset list

### DIFF
--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -233,9 +233,8 @@ export default Component.extend({
             const url = buildWithOptions(urlOptions);
             return `${url} ${targetWidth}w`;
           };
-          const addFallbackSrc = srcset => srcset.concat(src);
-
-          return addFallbackSrc(targetWidths.map(buildSrcSetPair)).join(', ');
+          
+          return targetWidths.map(buildSrcSetPair).join(', ');
         }
       })();
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "contributors": [
     "Frederick Fogerty <frederick.fogerty@gmail.com>",
     "Greg Larrenaga <greglarrenaga@gmail.com>",
+    "Sarah Crete <srhcrete@gmail.com>",
     "Sherwin Heydarbeygi <sherwin@imgix.com>"
   ],
   "directories": {

--- a/tests/unit/components/imgix-image-test.js
+++ b/tests/unit/components/imgix-image-test.js
@@ -38,7 +38,7 @@ module('Unit | Component | imgix image', function(hooks) {
   });
 
   test('the generated img has the correct number of srcsets', function(assert) {
-    const expectedNumberOfSrcSets = 32;
+    const expectedNumberOfSrcSets = 31;
 
     const component = this.owner.factoryFor('component:imgix-image').create();
     setProperties(component, {
@@ -49,6 +49,7 @@ module('Unit | Component | imgix image', function(hooks) {
     const actualNumberOfSrcSets = srcset.split(',').length;
     assert.equal(actualNumberOfSrcSets, expectedNumberOfSrcSets);
   });
+
   test('the generated img has srcsets in the correct format', function(assert) {
     const component = this.owner.factoryFor('component:imgix-image').create();
     setProperties(component, {
@@ -58,18 +59,12 @@ module('Unit | Component | imgix image', function(hooks) {
     const srcset = component.get('srcset');
     const srcsets = srcset.split(',').map(v => v.trim());
 
-    const srcsetsWithoutFallback = srcsets.slice(0, -1);
-
-    srcsetsWithoutFallback.forEach(srcset => {
+    srcsets.forEach(srcset => {
       assert.equal(srcset.split(' ').length, 2);
       const [url, width] = srcset.split(' ');
       assert.ok(url);
       assert.ok(width.match(/^\d+w$/));
     });
-
-    const fallbackSrcSet = srcsets[srcsets.length - 1];
-    assert.equal(fallbackSrcSet.split(' ').length, 1);
-    assert.notOk(fallbackSrcSet.match(/^\d+w$/));
   });
 
   test('the generated img should not contain a srcset when disableSrcSet is set', function(assert) {


### PR DESCRIPTION
### Description
Fixes issue [#69](https://github.com/imgix/ember-cli-imgix/issues/69) - we're currently adding a "sizeless" URL to the end of the srcset attributes as a "fallback source" which is incorrect. The "fallback source" for an image element should be provided in the src attribute, not at the end of the srcset list. 

### To Reproduce
N/A

### Expected Behavior
Every item in the srcset list should include a size descriptor, which in our case is always a width value or a resolution multiplier. Tests are still passing. 

