### PR TITLE
Fix(imgix-image.js): fixed dimensions mode updated to only pay attention to fixed width not fixed height

### DIFF
--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -155,7 +155,7 @@ export default Component.extend({
       const buildWithOptions = options =>
         client.buildURL(pathAsUri.path(), options);
 
-      const isFixedDimensionsMode = widthProp != null || heightProp != null;
+      const isFixedWidthMode = widthProp != null;
 
       const shouldShowDebugParams = get(config, 'APP.imgix.debug');
 
@@ -209,8 +209,8 @@ export default Component.extend({
           return;
         }
 
-        // w-type srcsets should not be used if one of the dimensions has been fixed as it will have no effect
-        if (isFixedDimensionsMode) {
+        // w-type srcsets should not be used if one of the width has been fixed as it will have no effect
+        if (isFixedWidthMode) {
           const buildWithDpr = dpr =>
             buildWithOptions({
               ...options,
@@ -233,7 +233,7 @@ export default Component.extend({
             const url = buildWithOptions(urlOptions);
             return `${url} ${targetWidth}w`;
           };
-          
+
           return targetWidths.map(buildSrcSetPair).join(', ');
         }
       })();

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -152,7 +152,7 @@ module('Integration | Component | imgix image', function(hooks) {
     module('fixed dimensions', function() {
       test(`it generates an ar parameter when passed as an option`, async function(assert) {
         await render(
-          hbs`<div>{{imgix-image path="/users/1.png" options=(hash ar="2:1") height=200 }}</div>`
+          hbs`<div>{{imgix-image path="/users/1.png" options=(hash ar="2:1") width=200 }}</div>`
         );
 
         expectSrcsTo(this.$, (_, urlURI) => {

--- a/tests/unit/components/imgix-image-test.js
+++ b/tests/unit/components/imgix-image-test.js
@@ -22,21 +22,6 @@ module('Unit | Component | imgix image', function(hooks) {
     });
   });
 
-  test('the generated img has a srcset in the format of 2x, 3x, 4x, 5x when passing a fixed height', function(assert) {
-    const component = this.owner.factoryFor('component:imgix-image').create();
-    setProperties(component, {
-      path: '/users/1.png',
-      height: 100
-    });
-
-    const srcset = component.get('srcset');
-    const actualNumberOfSrcSets = srcset.split(', ').length;
-    assert.equal(actualNumberOfSrcSets, 4);
-    srcset.split(', ').forEach(srcset => {
-      assert.ok(srcset.split(' ')[1].match(/^\dx$/));
-    });
-  });
-
   test('the generated img has the correct number of srcsets', function(assert) {
     const expectedNumberOfSrcSets = 31;
 


### PR DESCRIPTION
### Description

Currently, passing either a width or height to `imgix-image` sets `isFixedDimensionsMode` and prevents the generation of w-type srcsets. Since srcsets use only width as their sizing dimension, setting only a fixed height should not prevent w-type srcsets from being used.

Our specific use case here is a fixed-height image that spans the full width of a page. This image's aspect ratio will vary based on the viewport width and we want to have w-type srcsets generated using:

```
{{imgix-image path=imagePath height=400 sizes='100vw'}}
```

**Changes:** 

- renames `isFixedDimensionsMode` to `isFixedWidthMode` and stops using height as a factor

### Steps to Test
1.  Run `ember serve` and go to http://localhost:4200/ to check the dummy app and ensure nothing is broken
2.  Run `ember test` to ensure all tests are still passing