### PR TITLE
chore: change (missed) refs tof master to main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,14 +3,14 @@ Hello, and thanks for contributing to ember-cli-imgix! 🎉🙌
 
 **Before submitting a pull request,** please make sure the following is done:
 
-1.  Fork [the repository](https://github.com/imgix/ember-cli-imgix) and create your branch from `master`.
+1.  Fork [the repository](https://github.com/imgix/ember-cli-imgix) and create your branch from `main`.
 2.  Run `npm install` in the repository root.
 3.  If you've fixed a bug or added code that should be tested, add tests!
 4.  Ensure the test suite passes (`npm run test`). Tip: `npm run --watch` is helpful in development.
 5.  Format your code with [prettier](https://github.com/prettier/prettier) (`npm run format`). Don't worry too much if you haven't done this, we have a bot that will do this for you when you submit a PR.
 6.  Fill out the template below and delete everything above the line.
 
-**Learn more about contributing:** https://github.com/imgix/ember-cli-imgix/blob/master/CONTRIBUTING.md
+**Learn more about contributing:** https://github.com/imgix/ember-cli-imgix/blob/main/CONTRIBUTING.md
 
 ## tldr
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 
 branches:
   only:
-    - master
+    - main
     - version-2
 
 env:


### PR DESCRIPTION
This PR changes a few missed references to `master` in this project to `main`, one of which is causing issues for our CI tests.

Serves as a follow up to #151 CC: @frederickfogerty 