### PR TITLE
chore(test): add Embroider for ember compatibility testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ testem.log
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+yarn.lock.ember-try

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,3 +1,5 @@
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
+
 /* eslint-env node */
 module.exports = {
   useYarn: true,
@@ -32,6 +34,8 @@ module.exports = {
       npm: {
         devDependencies: {}
       }
-    }
+    },
+    embroiderSafe(),
+    embroiderOptimized(),
   ]
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const { maybeEmbroider } = require('@embroider/test-setup');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
@@ -15,5 +16,5 @@ module.exports = function(defaults) {
     app.import('vendor/ember/ember-template-compiler.js');
   }
 
-  return app.toTree();
+  return maybeEmbroider(app);
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@embroider/test-setup": "^0.47.1",
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^5.0.0",
     "ember-cli": "~3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -907,6 +907,14 @@
     ember-cli-babel "^6.12.0"
     ember-cli-htmlbars-inline-precompile "^1.0.0"
 
+"@embroider/test-setup@^0.47.1":
+  version "0.47.1"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.47.1.tgz#01f6921612b292cb721b2102b3f40dbc89131039"
+  integrity sha512-PKV+UBixVmkrXo/9AdrtvBccmTbTG9zgJUA/hvoHIGaUISW5cepWyLU0dqW3gE2ECJjrvc4+KtBUMOC1rEZ2Ng==
+  dependencies:
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+
 "@glimmer/di@^0.2.0":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.1.tgz#5286b6b32040232b751138f6d006130c728d4b3d"
@@ -6435,7 +6443,7 @@ lodash@^3.10.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
-lodash@^4.0.0, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8004,7 +8012,7 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==


### PR DESCRIPTION
## Description

This PR adds [Embroider](https://github.com/embroider-build/embroider) to the Ember Try compatibility scenarios as per https://github.com/embroider-build/embroider/tree/master/packages/test-setup. At the same time, I've also snuck in a git ignore change to avoid tracking yarn lock file generated when running tests with Ember Try.

Relates to issue https://github.com/imgix/ember-cli-imgix/issues/210.

## Checklist

I've omitted the checklists as none seem relevant.

## Steps to Test

```js
yarn test
```

Fwiw at this stage the project does not support Embroider (see https://github.com/imgix/ember-cli-imgix/issues/210) so the new Embroider test scenarios are failing (along with Ember 4 as thats the latest beta these days, but thats the same issue on master).

```
=== Scenario: embroider-safe ===================================================

WARNING: Node v12.22.6 is not tested against Ember CLI on your platform. We recommend that you use the most-recent "Active LTS" version of Node.js. See https://git.io/v7S5n for details.
Could not start watchman
Visit https://ember-cli.com/user-guide/#watchman for more info.
⠋ BuildingSuccessfully applied EMBROIDER_TEST_SETUP_OPTIONS=safe
Building into /private/var/folders/_b/525y2kfj6sg6l_gbcnf29qsm0000gp/T/embroider/bb304d
this.app.getLintTests is not a function


Stack Trace and Error Report: /var/folders/_b/525y2kfj6sg6l_gbcnf29qsm0000gp/T/error.dump.31dc14f166c3e744856c7a7100b397e1.log
Result: false
---

WARNING: Node v12.22.6 is not tested against Ember CLI on your platform. We recommend that you use the most-recent "Active LTS" version of Node.js. See https://git.io/v7S5n for details.
Could not start watchman
Visit https://ember-cli.com/user-guide/#watchman for more info.
⠋ BuildingSuccessfully applied EMBROIDER_TEST_SETUP_OPTIONS=optimized
Building into /private/var/folders/_b/525y2kfj6sg6l_gbcnf29qsm0000gp/T/embroider/bb304d
this.app.getLintTests is not a function


Stack Trace and Error Report: /var/folders/_b/525y2kfj6sg6l_gbcnf29qsm0000gp/T/error.dump.c6444d6319e3490b340c3200a442e7b5.log

Result: false
---

------ RESULTS ------
...
Command run: ember test
Scenario embroider-safe: FAIL
Command run: ember test
with env: {
  "EMBROIDER_TEST_SETUP_OPTIONS": "safe"
}
┌────────────────────┬────────────────────┬──────────────────────────────┬──────────┐
│ Dependency         │ Expected           │ Used                         │ Type     │
├────────────────────┼────────────────────┼──────────────────────────────┼──────────┤
│ @embroider/core    │ 0.47.1             │ 0.47.1                       │ yarn     │
├────────────────────┼────────────────────┼──────────────────────────────┼──────────┤
│ @embroider/webpack │ 0.47.1             │ 0.47.1                       │ yarn     │
├────────────────────┼────────────────────┼──────────────────────────────┼──────────┤
│ @embroider/compat  │ 0.47.1             │ 0.47.1                       │ yarn     │
├────────────────────┼────────────────────┼──────────────────────────────┼──────────┤
│ webpack            │ ^5.0.0             │ 5.60.0                       │ yarn     │
└────────────────────┴────────────────────┴──────────────────────────────┴──────────┘

Scenario embroider-optimized: FAIL
Command run: ember test
with env: {
  "EMBROIDER_TEST_SETUP_OPTIONS": "optimized"
}
┌────────────────────┬────────────────────┬──────────────────────────────┬──────────┐
│ Dependency         │ Expected           │ Used                         │ Type     │
├────────────────────┼────────────────────┼──────────────────────────────┼──────────┤
│ @embroider/core    │ 0.47.1             │ 0.47.1                       │ yarn     │
├────────────────────┼────────────────────┼──────────────────────────────┼──────────┤
│ @embroider/webpack │ 0.47.1             │ 0.47.1                       │ yarn     │
├────────────────────┼────────────────────┼──────────────────────────────┼──────────┤
│ @embroider/compat  │ 0.47.1             │ 0.47.1                       │ yarn     │
├────────────────────┼────────────────────┼──────────────────────────────┼──────────┤
│ webpack            │ ^5.0.0             │ 5.60.0                       │ yarn     │
└────────────────────┴────────────────────┴──────────────────────────────┴──────────┘


3 scenarios failed
3 scenarios succeeded
```
