### PR TITLE
feat/add-secure-url-token-to-imgix-global-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ imgix: {
     src: string
     srcset: string
     sizes: string
-  }
+  },
+  secureURLToken?: string
 }
 ```
 
@@ -84,6 +85,7 @@ module.exports = function(environment) {
         debug: true, // Prints out diagnostic information on the image itself. Turn off in production.
         classNames: 'imgix-image', // default class used on the img element
         defaultParams: {}, // optional params that will be used in all generated paths
+        secureURLToken: 'sometoken', // optional token used to generate secure URLs
       }
     }
     // snip

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ imgix: {
     srcset: string
     sizes: string
   },
+  classNames?: string,
+  defaultParams?: {},
   secureURLToken?: string
 }
 ```

--- a/addon/components/imgix-bg.js
+++ b/addon/components/imgix-bg.js
@@ -77,7 +77,8 @@ export default Component.extend(ResizeAware, {
       includeLibraryParam: false, // to disable imgix-core-js setting ixlib=js by default
       libraryParam: disableLibraryParam
         ? undefined
-        : `ember-${constants.APP_VERSION}`
+        : `ember-${constants.APP_VERSION}`,
+      secureURLToken: config.APP.imgix.secureURLToken
     });
   }),
 

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -122,7 +122,8 @@ export default Component.extend({
       includeLibraryParam: false, // to disable imgix-core-js setting ixlib=js by default
       libraryParam: disableLibraryParam
         ? undefined
-        : `ember-${constants.APP_VERSION}`
+        : `ember-${constants.APP_VERSION}`,
+      secureURLToken: config.APP.imgix.secureURLToken
     });
   }),
 

--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -171,7 +171,8 @@ export default Mixin.create({
       includeLibraryParam: false, // to disable imgix-core-js setting ixlib=js by default
       libraryParam: disableLibraryParam
         ? undefined
-        : `ember-${constants.APP_VERSION}`
+        : `ember-${constants.APP_VERSION}`,
+      secureURLToken: config.APP.imgix.secureURLToken
     });
   }),
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "Frederick Fogerty <frederick.fogerty@gmail.com>",
     "Greg Larrenaga <greglarrenaga@gmail.com>",
     "Sarah Crete <srhcrete@gmail.com>",
-    "Sherwin Heydarbeygi <sherwin@imgix.com>"
+    "Sherwin Heydarbeygi <sherwin@imgix.com>",
+    "Rahul Kumar <rahulkumar28@outlook.co.nz>"
   ],
   "directories": {
     "doc": "doc",

--- a/tests/integration/components/imgix-background-test.js
+++ b/tests/integration/components/imgix-background-test.js
@@ -514,9 +514,59 @@ module('Integration | Component | imgix background', function(hooks) {
               Content
             {{/imgix-bg}}
           </div>
-          `);
+          `
+        );
 
-        expectSrcsTo(this.$, (_, uri) => assert.equal(uri.getQueryParamValue('auto'), 'format'));
+        expectSrcsTo(this.$, (_, uri) =>
+          assert.equal(uri.getQueryParamValue('auto'), 'format')
+        );
+      });
+    });
+
+    module('secure url token', function () {
+      test('is included as a query parameter when configured ', async function (assert) {
+        config.APP.imgix.secureURLToken = 'sometoken';
+
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png"
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+        `
+        );
+
+        expectSrcsTo(this.$, (_, uri) => {
+          const secureParam = uri.getQueryParamValue('s');
+          assert.ok(secureParam);
+        });
+      });
+
+      test('is omitted as a query parameter when not configured ', async function (assert) {
+        // Explicitly set it to undefined
+        config.APP.imgix.secureURLToken = undefined;
+
+        await render(
+          hbs`
+          <div>
+            <style>.imgix-bg { width: 1250px; height: 200px;}</style>
+            {{#imgix-bg
+              path="/users/1.png"
+            }}
+              Content
+            {{/imgix-bg}}
+          </div>
+        `
+        );
+
+        expectSrcsTo(this.$, (_, uri) => {
+          const secureParam = uri.getQueryParamValue('s');
+          assert.notOk(secureParam);
+        });
       });
     });
   });

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -358,7 +358,38 @@ module('Integration | Component | imgix image', function(hooks) {
           hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png?auto=format'}}</div>`
         );
 
-        expectSrcsTo(this.$, (_, uri) => assert.equal(uri.getQueryParamValue('auto'), 'format'));
+        expectSrcsTo(this.$, (_, uri) =>
+          assert.equal(uri.getQueryParamValue('auto'), 'format')
+        );
+      });
+    });
+
+    module('secure url token', function () {
+      test('is included as a query parameter when configured ', async function (assert) {
+        config.APP.imgix.secureURLToken = 'sometoken';
+
+        await render(
+          hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png'}}</div>`
+        );
+
+        expectSrcsTo(this.$, (_, uri) => {
+          const secureParam = uri.getQueryParamValue('s');
+          assert.ok(secureParam);
+        });
+      });
+
+      test('is omitted as a query parameter when not configured ', async function (assert) {
+        // Explicitly set it to undefined
+        config.APP.imgix.secureURLToken = undefined;
+
+        await render(
+          hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png'}}</div>`
+        );
+
+        expectSrcsTo(this.$, (_, uri) => {
+          const secureParam = uri.getQueryParamValue('s');
+          assert.notOk(secureParam);
+        });
       });
     });
   });


### PR DESCRIPTION
## Description

This PR adds support for the `secureURLToken` parameter from [imgix-core-js](https://github.com/imgix/js-core#configuration) by passing this through if it configured in the Ember application's Imgix configuration.

This is a non-breaking feature and should be releasable in a minor.

### New Feature

- NA - If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [ ] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

* Setup `ember-cli-imgix` with an Imgix source which requires secure tokens to be provided with images. Without passing through `secureURLToken` these image requests should be failing and returning a 403 forbidden.
* Add the global configuration for `secureURLToken` and restart your Ember app
* The images should now come back successfully.

I've verified this against our internal application however do not have a token or demo app I could share for this unfortunately.