### PR TITLE
chore: use large resource_class for circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     docker:
       - image: 'cimg/node:12.22-browsers'
-    resource_class: xlarge
+    resource_class: large
     steps:
       - checkout
       - browser-tools/install-chrome


### PR DESCRIPTION
[Looks like](https://app.circleci.com/pipelines/github/imgix/ember-cli-imgix/8/workflows/a58efe2e-feab-485a-b7d1-6283f7606aa5/jobs/10/resources) we can afford to just use the large resource_class and save some CircleCI credits