### PR TITLE
chore: enable embroider ember try configuration options

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -78,15 +78,14 @@ module.exports = async function () {
           },
         },
       },
-      // Remove Embroider builds for now as there are compat issues
-      // {
-      //   ...embroiderSafe(),
-      //   allowedToFail: true,
-      // },
-      // {
-      //   ...embroiderOptimized(),
-      //   allowedToFail: true,
-      // }
+      {
+        ...embroiderSafe(),
+        allowedToFail: true,
+      },
+      {
+        ...embroiderOptimized(),
+        allowedToFail: true,
+      },
     ],
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -11,9 +11,9 @@ module.exports = function (defaults) {
     },
   });
 
-  if (app.env === 'test') {
-    app.import('vendor/ember/ember-template-compiler.js');
-  }
+  // if (app.env === 'test') {
+  //   app.import('vendor/ember/ember-template-compiler.js');
+  // }
 
   const { maybeEmbroider } = require('@embroider/test-setup');
   return maybeEmbroider(app, {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.4.2",
-    "@embroider/test-setup": "^0.43.5",
+    "@embroider/test-setup": "^0.48.1",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1881,10 +1881,10 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/test-setup@^0.43.5":
-  version "0.43.5"
-  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.43.5.tgz#79944cb50038802cc71d50aa0d5d7a0955ee6349"
-  integrity sha512-ke+5B0VR2343ZrOqV9Ok2LyA4m2q2ApM1Oy1RC8+3+OI5lDVg8UgZG9n/G2e77KPMFxnK3eVpXcPdLcdOxW6+w==
+"@embroider/test-setup@^0.48.1":
+  version "0.48.1"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.48.1.tgz#f64da84f8241433d0ba92154fa1eb3137ecd4df8"
+  integrity sha512-MmYTgQMDVDrZPvxeT27LTUD/BOum21ip1tEYv5H/StSeTZyZQ861Q+8HXQUFTVF/HFjGAB1c/BAgnw+8hO1ueA==
   dependencies:
     lodash "^4.17.21"
     resolve "^1.20.0"


### PR DESCRIPTION
## Description

Enable embroider safe and optimized options in ember try config. This is now passing since Embroider 0.48.1 works with ember-cli-imgix.
