### PR TITLE
fix: update htmlSafe import to @ember/template rather than @ember/string

### DIFF
--- a/addon/components/imgix-bg.js
+++ b/addon/components/imgix-bg.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed, set } from '@ember/object';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import config from 'ember-get-config';
 import ResizeAware from 'ember-resize-aware/mixins/resize-aware';
 import { toFixed, constants, targetWidths, findClosest } from '../common';


### PR DESCRIPTION
## Description
Update htmlSafe import to @ember/template as the current usage is invalid when using Ember@3.27+. This fixes the following warnings when using these Ember versions (note that ember@3.28 is an LTS so its likely to be the version people use for a while yet).

```
WARNING in ./node_modules/ember-cli-imgix/components/imgix-bg.js 111:11-19
export 'htmlSafe' (imported as 'htmlSafe') was not found in '@ember/string' (possible exports: camelize, capitalize, classify, dasherize, decamelize, getString, getStrings, loc, setStrings, underscore, w)
 @ ./components/imgix-bg.js 1:0-78 1:0-78
 @ ./assets/my-app 864:9-45
```

### Bug Fix

- [ ] All existing unit tests are still passing (if applicable)
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`

### Steps to test

This has only been tested using unit tests. It probably is worth testing this against a real world ember app prior to merging (or we send it as its unlikely this will break things).