### PR TITLE
ci(build): add build test step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
       - run:
           name: Test compat
           command: yarn test:ember-compatibility
+      - run:
+          name: Test build
+          command: yarn build
 
 workflows:
   test-frontend:


### PR DESCRIPTION
Adds an additional test step to our CircleCI process to test successful builds.

# Before

Problems with builds can only be detected by CircleCI during the `deploy` step; this step only runs on `main` and prerelease branches. As a result, commits that break builds (included automated dependency updates by Renovate) in many cases might not be detected until after merge.
# After

We now test for a successful `build` step on every branch.