### PR TITLE
ci(deploy): adds prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
-    "prepare": "ember build",
     "prepublishOnly": "ember build",
     "start": "ember server",
     "test": "npm-run-all test:*",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
+    "prepare": "ember build",
+    "prepublishOnly": "ember build",
     "start": "ember server",
     "test": "npm-run-all test:*",
     "test:ember": "ember test",


### PR DESCRIPTION
Adds additional scripts to ensure properly updated `dist` prior to release.

# Before

Library is not guaranteed to execute a `build` step to properly update `dist` directory prior to deployment; as a result, some libraries include the prior release in their `dist` folder.

# After

We include both a `prepublishOnly` step to ensure that the library executes a build prior to deploying a release.