### PR TITLE
chore: replace usage of EmberError with native Error

### DIFF
--- a/addon/components/imgix-bg.js
+++ b/addon/components/imgix-bg.js
@@ -5,7 +5,6 @@ import config from 'ember-get-config';
 import ResizeAware from 'ember-resize-aware/mixins/resize-aware';
 import { toFixed, constants, targetWidths, findClosest } from '../common';
 import URI from 'jsuri';
-import EmberError from '@ember/error';
 import ImgixClient from '@imgix/js-core';
 
 const buildDebugParams = ({ width, height }) => {
@@ -64,7 +63,7 @@ export default Component.extend(ResizeAware, {
 
   _client: computed('disableLibraryParam', function () {
     if (!config || !config.APP.imgix.source) {
-      throw new EmberError(
+      throw new Error(
         'Could not find a source in the application configuration. Please configure APP.imgix.source in config/environment.js. See https://github.com/imgix/ember-cli-imgix for more information.'
       );
     }

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import config from 'ember-get-config';
-import EmberError from '@ember/error';
 import ImgixClient from '@imgix/js-core';
 import URI from 'jsuri';
 import { debounce } from '@ember/runloop';
@@ -108,7 +107,7 @@ export default Component.extend({
 
   _client: computed('disableLibraryParam', function () {
     if (!config || !config.APP.imgix.source) {
-      throw new EmberError(
+      throw new Error(
         'Could not find a source in the application configuration. Please configure APP.imgix.source in config/environment.js. See https://github.com/imgix/ember-cli-imgix for more information.'
       );
     }

--- a/addon/mixins/imgix-path-behavior.js
+++ b/addon/mixins/imgix-path-behavior.js
@@ -4,7 +4,6 @@ import { reads } from '@ember/object/computed';
 import { merge } from '@ember/polyfills';
 import { schedule, debounce } from '@ember/runloop';
 import { getOwner } from '@ember/application';
-import EmberError from '@ember/error';
 import ImgixClient from '@imgix/js-core';
 import config from 'ember-get-config';
 import URI from 'jsuri';
@@ -149,13 +148,13 @@ export default Mixin.create({
 
   /**
    * @property ImgixClient instantiated ImgixClient
-   * @throws {EmberError} Will throw an error if the imgix config information is not found in config/environment.js
+   * @throws {Error} Will throw an error if the imgix config information is not found in config/environment.js
    * @return ImgixClient return an instantiated ImgixClient instance.
    */
   _client: computed('_config', 'disableLibraryParam', function () {
     let env = this._config;
     if (!env || !env.APP.imgix.source) {
-      throw new EmberError(
+      throw new Error(
         'Could not find a source in the application configuration. Please configure APP.imgix.source in config/environment.js. See https://github.com/imgix/ember-cli-imgix for more information.'
       );
     }


### PR DESCRIPTION
Required for Ember 5 support as this v4 deprecation was removed in v5.

Reference on [Ember Deprecations](https://deprecations.emberjs.com/v4.x/#toc_deprecate-ember-error):

> Use of @ember/error is deprecated. This package merely re-exports the native Error class. You should replace any uses of @ember/error with the native Error.